### PR TITLE
handle empty selects or sequences

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doenet/assignment-viewer",
-    "private": true,
+    "private": false,
     "description": "View assignments from questions written in DoenetML",
     "version": "0.1.0-alpha1",
     "license": "AGPL-3.0-or-later",

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -435,7 +435,18 @@ export function getItemSequence(state: ActivityState): string[] {
     } else {
         const numAttempts = state.attempts.length;
         if (numAttempts === 0) {
-            return [state.id];
+            if (state.latestChildStates.length === 0) {
+                return [];
+            } else {
+                const prelimResult = state.latestChildStates.flatMap((a) =>
+                    getItemSequence(a),
+                );
+                if (state.type === "sequence") {
+                    return prelimResult;
+                } else {
+                    return prelimResult.slice(0, state.source.numToSelect);
+                }
+            }
         }
         return state.attempts[numAttempts - 1].activities.flatMap((a) =>
             getItemSequence(a),

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -307,6 +307,10 @@ export function generateNewSelectAttempt({
     const numToSelect = source.numToSelect;
     const numChildren = state.latestChildStates.length;
 
+    if (numChildren === 0) {
+        return { finalQuestionCounter: initialQuestionCounter, state };
+    }
+
     // If the child's variants have already been broken up into slices via `initializeSelectState`, above,
     // this calculation based on activity state will take that into account.
     // In particular, if `numToSelect` > 1, each child should report just one variant.
@@ -324,7 +328,7 @@ export function generateNewSelectAttempt({
     if (numToSelect > totalNumOptions) {
         if (source.selectByVariant) {
             throw Error(
-                "The specified number to select of a select activity is larger than the number of available variants.",
+                `For a select activity, "number to select" is ${numToSelect.toString()}, which is larger than the number of available variants (${totalNumOptions.toString()}).`,
             );
         } else {
             const totalNumChildVariants = numVariantsPerChild.reduce(
@@ -332,11 +336,11 @@ export function generateNewSelectAttempt({
             );
             if (numToSelect > totalNumChildVariants) {
                 throw Error(
-                    "The specified number to select of a select activity is larger than the number of available activities.",
+                    `For a select activity, "number to select" is ${numToSelect.toString()}, which is larger than the number of available activities (${totalNumOptions.toString()}).`,
                 );
             } else {
                 throw Error(
-                    'The specified number to select of a select activity is larger than the number of available activities. Turning on "select by variant" will add enough options for the select activity to function.',
+                    `For a select activity, "number to select" is ${numToSelect.toString()}, which is larger than the number of available activities (${totalNumOptions.toString()}). (Turning on "select by variant" will add enough options for the select activity to function.)`,
                 );
             }
         }

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -527,7 +527,7 @@ export function Viewer({
                             borderRadius: "10px",
                             padding: "5px 20px",
                         }}
-                        disabled={currentItemIdx === 0}
+                        disabled={currentItemIdx <= 0}
                     >
                         Previous
                     </button>
@@ -540,14 +540,14 @@ export function Viewer({
                             borderRadius: "10px",
                             padding: "5px 20px",
                         }}
-                        disabled={currentItemIdx === numItems - 1}
+                        disabled={currentItemIdx >= numItems - 1}
                     >
                         Next
                     </button>
                     {activityLevelAttempts ? (
                         <button
                             onClick={generateActivityAttempt}
-                            disabled={!initialized}
+                            disabled={!initialized || numItems === 0}
                             style={{
                                 marginLeft: "30px",
                                 backgroundColor: "lightgray",
@@ -562,7 +562,7 @@ export function Viewer({
             </div>
 
             <div
-                hidden={itemsRendered.length > 0}
+                hidden={itemsRendered.length > 0 || numItems === 0}
                 style={{ marginLeft: "20px", marginTop: "20px" }}
             >
                 Initializing...

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -157,23 +157,28 @@ type ErrorProps = {
     children?: ReactNode;
 };
 
-type ErrorState = { hasError: boolean };
+type ErrorState = { hasError: boolean; message: string };
 
 class ErrorBoundary extends Component<ErrorProps, ErrorState> {
     constructor(props: ErrorProps) {
         super(props);
-        this.state = { hasError: false };
+        this.state = { hasError: false, message: "" };
     }
 
-    static getDerivedStateFromError(_: Error): ErrorState {
-        return { hasError: true };
+    static getDerivedStateFromError(error: Error): ErrorState {
+        return { hasError: true, message: error.message };
     }
     componentDidCatch(error: Error, errorInfo: ErrorInfo) {
         console.error("Uncaught error", error, errorInfo);
     }
     render() {
         if (this.state.hasError) {
-            return <h1>Sorry, something went wrong</h1>;
+            return (
+                <div style={{ marginLeft: "20px" }}>
+                    <h1>An error occurred</h1>
+                    <p>{this.state.message}</p>
+                </div>
+            );
         }
         return this.props.children;
     }

--- a/src/test/activityState.test.ts
+++ b/src/test/activityState.test.ts
@@ -17,6 +17,10 @@ import invalidId from "./testSources/invalidId.json";
 import selMult2docs from "./testSources/selMult2docs.json";
 import selMult1doc from "./testSources/selMult1doc.json";
 import selMult1docNoVariant from "./testSources/selMult1docNoVariant.json";
+import sel0 from "./testSources/sel0.json";
+import seq0 from "./testSources/seq0.json";
+import seq2Sel0 from "./testSources/seq2Sel0.json";
+import seqSel0Sel from "./testSources/seqSel0Sel.json";
 
 import { SelectSource, SelectState } from "../Activity/selectState";
 import { SequenceSource, SequenceState } from "../Activity/sequenceState";
@@ -448,6 +452,94 @@ describe("Activity state tests", () => {
                 docFromFirstSelect,
             ]);
         }
+    });
+
+    it("get item sequence, select from 0", () => {
+        const source = sel0 as SelectSource;
+        const initialState = initializeActivityState({
+            source,
+            variant: 1,
+            parentId: null,
+            numActivityVariants,
+        }) as SelectState;
+
+        const { state } = generateNewActivityAttempt({
+            state: initialState,
+            numActivityVariants,
+            initialQuestionCounter: 1,
+            questionCounts,
+            parentAttempt: 1,
+        });
+
+        expect(getItemSequence(state)).eqls([]);
+    });
+
+    it("get item sequence, sequence of 0", () => {
+        const source = seq0 as SequenceSource;
+        const initialState = initializeActivityState({
+            source,
+            variant: 1,
+            parentId: null,
+            numActivityVariants,
+        }) as SequenceState;
+
+        const { state } = generateNewActivityAttempt({
+            state: initialState,
+            numActivityVariants,
+            initialQuestionCounter: 1,
+            questionCounts,
+            parentAttempt: 1,
+        });
+
+        expect(getItemSequence(state)).eqls([]);
+    });
+
+    it("get item sequence, sequence of two selects from 0", () => {
+        const source = seq2Sel0 as SequenceSource;
+        const initialState = initializeActivityState({
+            source,
+            variant: 1,
+            parentId: null,
+            numActivityVariants,
+        }) as SequenceState;
+
+        const { state } = generateNewActivityAttempt({
+            state: initialState,
+            numActivityVariants,
+            initialQuestionCounter: 1,
+            questionCounts,
+            parentAttempt: 1,
+        });
+
+        expect(getItemSequence(state)).eqls([]);
+    });
+
+    it("get item sequence, sequence of select from 0 and select", () => {
+        const source = seqSel0Sel as SequenceSource;
+        const initialState = initializeActivityState({
+            source,
+            variant: 1,
+            parentId: null,
+            numActivityVariants,
+        }) as SequenceState;
+
+        const { state: newState } = generateNewActivityAttempt({
+            state: initialState,
+            numActivityVariants,
+            initialQuestionCounter: 1,
+            questionCounts,
+            parentAttempt: 1,
+        });
+
+        const state = newState as SequenceState;
+
+        const secondSelectState = state.latestChildStates[1] as SelectState;
+
+        const docFromSecondSelect =
+            secondSelectState.attempts[0].activities[0].id;
+        expect(["doc3", "doc2", "doc1"].includes(docFromSecondSelect)).eq(true);
+
+        expect(getItemSequence(state)).eqls([docFromSecondSelect]);
     });
 
     it("error when select multiple from a single doc with selectByVariant=false", () => {

--- a/src/test/testSources/sel0.json
+++ b/src/test/testSources/sel0.json
@@ -1,0 +1,8 @@
+{
+    "title": "My select",
+    "id": "seq",
+    "type": "select",
+    "selectByVariant": true,
+    "numToSelect": 1,
+    "items": []
+}

--- a/src/test/testSources/seq0.json
+++ b/src/test/testSources/seq0.json
@@ -1,0 +1,7 @@
+{
+    "title": "My sequence",
+    "id": "seq",
+    "type": "sequence",
+    "shuffle": false,
+    "items": []
+}

--- a/src/test/testSources/seq2Sel0.json
+++ b/src/test/testSources/seq2Sel0.json
@@ -1,0 +1,22 @@
+{
+    "title": "My sequence",
+    "id": "seq",
+    "type": "sequence",
+    "shuffle": true,
+    "items": [
+        {
+            "id": "sel1",
+            "type": "select",
+            "selectByVariant": true,
+            "numToSelect": 1,
+            "items": []
+        },
+        {
+            "id": "sel2",
+            "type": "select",
+            "selectByVariant": true,
+            "numToSelect": 1,
+            "items": []
+        }
+    ]
+}

--- a/src/test/testSources/seqSel0Sel.json
+++ b/src/test/testSources/seqSel0Sel.json
@@ -1,0 +1,44 @@
+{
+    "title": "My sequence",
+    "id": "seq",
+    "type": "sequence",
+    "shuffle": false,
+    "items": [
+        {
+            "id": "sel1",
+            "type": "select",
+            "selectByVariant": true,
+            "numToSelect": 1,
+            "items": []
+        },
+        {
+            "id": "sel2",
+            "type": "select",
+            "selectByVariant": true,
+            "numToSelect": 1,
+            "items": [
+                {
+                    "id": "doc3",
+                    "type": "singleDoc",
+                    "isDescription": false,
+                    "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
+                    "version": "0.7.0-alpha30"
+                },
+                {
+                    "id": "doc2",
+                    "type": "singleDoc",
+                    "isDescription": false,
+                    "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
+                    "version": "0.7.0-alpha30"
+                },
+                {
+                    "id": "doc1",
+                    "type": "singleDoc",
+                    "isDescription": false,
+                    "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
+                    "version": "0.7.0-alpha30"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
If a select or sequence has no children, it is not added to the item sequence.

The message of error caught by the error boundary is displayed. In particular, if `numToSelect` of a select is too large, a message stating the nature of the problem is displayed.