### PR TITLE
store document structure in source rather than calculate it

### DIFF
--- a/dev/testActivity.json
+++ b/dev/testActivity.json
@@ -9,14 +9,16 @@
             "id": "sel",
             "type": "select",
             "selectByVariant": true,
-            "numToSelect": 1,
+            "numToSelect": 2,
             "items": [
                 {
                     "id": "qrf",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>2+2=<answer>4</answer><selectFromSequence /></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 10,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "title": "My activity",
@@ -24,7 +26,9 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>1+1=<answer>2</answer><selectFromSequence length='3' /></problem><problem>4+4=<answer>8</answer><selectFromSequence length='4' /></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 12,
+                    "baseLevelComponentCounts": { "problem": 2 }
                 }
             ]
         },
@@ -39,28 +43,36 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1A <graph><point name='P'/></graph><answer><award><when>$P.x > 0</when></award></answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 1,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "sel2b",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1B <p>Enter: <select assignNames='a'>a b c</select>. <answer>$a</answer></p></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 3,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "sel2c",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1C <p>Enter: <selectFromSequence assignNames='a' />. <answer>$a</answer></p></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 10,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "sel2d",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1D <p>Enter: <selectFromSequence assignNames='a' length=\"5\" />.  <answer>$a</answer></p></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 5,
+                    "baseLevelComponentCounts": { "question": 1 }
                 }
             ]
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha1",
+    "version": "0.1.0-alpha2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha1",
+            "version": "0.1.0-alpha2",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@doenet/doenetml-iframe": "^0.7.0-alpha30",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha1",
+    "version": "0.1.0-alpha2",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -16,7 +16,6 @@ export function Activity({
     showAnswerTitles = false,
     state,
     reportScoreAndStateCallback,
-    documentStructureCallback,
     checkRender,
     checkHidden,
     allowItemAttemptButtons = false,
@@ -36,7 +35,6 @@ export function Activity({
     showAnswerTitles?: boolean;
     state: ActivityState;
     reportScoreAndStateCallback: (args: unknown) => void;
-    documentStructureCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
     allowItemAttemptButtons?: boolean;
@@ -63,7 +61,6 @@ export function Activity({
                     showAnswerTitles={showAnswerTitles}
                     state={state}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={documentStructureCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
                     allowItemAttemptButtons={allowItemAttemptButtons}
@@ -88,7 +85,6 @@ export function Activity({
                     showAnswerTitles={showAnswerTitles}
                     state={state}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={documentStructureCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
                     allowItemAttemptButtons={allowItemAttemptButtons}
@@ -113,7 +109,6 @@ export function Activity({
                     showAnswerTitles={showAnswerTitles}
                     state={state}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={documentStructureCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
                     allowItemAttemptButtons={allowItemAttemptButtons}

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -16,7 +16,6 @@ export function SelectActivity({
     showAnswerTitles = false,
     state,
     reportScoreAndStateCallback,
-    documentStructureCallback,
     checkRender,
     checkHidden,
     allowItemAttemptButtons = false,
@@ -36,7 +35,6 @@ export function SelectActivity({
     showAnswerTitles?: boolean;
     state: SelectState;
     reportScoreAndStateCallback: (args: unknown) => void;
-    documentStructureCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
     allowItemAttemptButtons?: boolean;
@@ -72,7 +70,6 @@ export function SelectActivity({
                     darkMode={darkMode}
                     showAnswerTitles={showAnswerTitles}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={documentStructureCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
                     allowItemAttemptButtons={allowItemAttemptButtons}
@@ -86,31 +83,6 @@ export function SelectActivity({
         }
     }
 
-    const unselectedActivities = state.latestChildStates
-        .filter((activity) => !selectedIds.includes(activity.id))
-        .map((activity) => (
-            <Activity
-                key={activity.id}
-                state={activity}
-                flags={flags}
-                baseId={baseId}
-                forceDisable={forceDisable}
-                forceShowCorrectness={forceShowCorrectness}
-                forceShowSolution={forceShowSolution}
-                forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                linkSettings={linkSettings}
-                darkMode={darkMode}
-                showAnswerTitles={showAnswerTitles}
-                reportScoreAndStateCallback={reportScoreAndStateCallback}
-                documentStructureCallback={documentStructureCallback}
-                checkRender={() => false}
-                checkHidden={checkHidden}
-                hasRenderedCallback={hasRenderedCallback}
-                reportVisibility={reportVisibility}
-                reportVisibilityCallback={reportVisibilityCallback}
-            />
-        ));
-
     return (
         <div
             key={
@@ -123,7 +95,6 @@ export function SelectActivity({
             hidden={!checkRender(state)}
         >
             <div>{selectedActivities}</div>
-            <div hidden={true}>{unselectedActivities}</div>
         </div>
     );
 }

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -16,7 +16,6 @@ export function SequenceActivity({
     showAnswerTitles = false,
     state,
     reportScoreAndStateCallback,
-    documentStructureCallback,
     checkRender,
     checkHidden,
     allowItemAttemptButtons = false,
@@ -36,7 +35,6 @@ export function SequenceActivity({
     showAnswerTitles?: boolean;
     state: SequenceState;
     reportScoreAndStateCallback: (args: unknown) => void;
-    documentStructureCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
     allowItemAttemptButtons?: boolean;
@@ -71,35 +69,6 @@ export function SequenceActivity({
                     darkMode={darkMode}
                     showAnswerTitles={showAnswerTitles}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={documentStructureCallback}
-                    checkRender={checkRender}
-                    checkHidden={checkHidden}
-                    allowItemAttemptButtons={allowItemAttemptButtons}
-                    generateNewItemAttempt={generateNewItemAttempt}
-                    hasRenderedCallback={hasRenderedCallback}
-                    reportVisibility={reportVisibility}
-                    reportVisibilityCallback={reportVisibilityCallback}
-                />,
-            );
-        }
-    } else {
-        // if don't have latest attempt, just create from the data we have
-        for (const activity of state.latestChildStates) {
-            activityList.push(
-                <Activity
-                    key={activity.id}
-                    state={activity}
-                    flags={flags}
-                    baseId={baseId}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    linkSettings={linkSettings}
-                    darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={documentStructureCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
                     allowItemAttemptButtons={allowItemAttemptButtons}

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -16,7 +16,6 @@ export function SingleDocActivity({
     showAnswerTitles = false,
     state,
     reportScoreAndStateCallback,
-    documentStructureCallback,
     checkRender,
     checkHidden,
     allowItemAttemptButtons = false,
@@ -36,7 +35,6 @@ export function SingleDocActivity({
     showAnswerTitles?: boolean;
     state: SingleDocState;
     reportScoreAndStateCallback: (args: unknown) => void;
-    documentStructureCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
     allowItemAttemptButtons?: boolean;
@@ -128,9 +126,6 @@ export function SingleDocActivity({
     return (
         <div ref={ref}>
             <div hidden={!render || hidden} style={{ minHeight: "100px" }}>
-                {/* <div style={{ marginLeft: "20px" }} hidden={rendered}>
-                    Initializing...
-                </div> */}
                 <DoenetViewer
                     key={state.attempts.length}
                     doenetML={source.doenetML}
@@ -152,9 +147,6 @@ export function SingleDocActivity({
                     initialState={initialDoenetState}
                     initializeCounters={initialCounters}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    documentStructureCallback={(args: unknown) => {
-                        documentStructureCallback(args);
-                    }}
                     initializedCallback={() => {
                         setRendered(true);
                         hasRenderedCallback(state.id);

--- a/src/Activity/singleDocState.ts
+++ b/src/Activity/singleDocState.ts
@@ -21,6 +21,10 @@ export type SingleDocSource = {
     doenetML: string;
     /** The version of DoenetML that should be used to render this activity. */
     version: string;
+    /** The number of variants present in `doenetML` */
+    numVariants?: number;
+    /** The number each component type among the base level children (direct children of document) in `doenetML` */
+    baseLevelComponentCounts?: Record<string, number | undefined>;
 };
 
 /** The current state of a single doc activity, including all attempts. */

--- a/src/test/generateVariants.test.ts
+++ b/src/test/generateVariants.test.ts
@@ -18,6 +18,7 @@ import {
     SequenceState,
 } from "../Activity/sequenceState";
 import {
+    gatherDocumentStructure,
     generateNewActivityAttempt,
     initializeActivityState,
 } from "../Activity/activityState";
@@ -32,29 +33,11 @@ import {
     SelectState,
 } from "../Activity/selectState";
 
-const numActivityVariants = {
-    doc1: 1,
-    doc2: 2,
-    doc3: 3,
-    doc4: 4,
-    doc5: 5,
-    doc1a: 1,
-    doc3a: 3,
-};
-
-const questionCounts = {
-    doc1: 1,
-    doc2: 1,
-    doc3: 1,
-    doc4: 1,
-    doc5: 1,
-    doc1a: 1,
-    doc3a: 1,
-};
-
 describe("Test of generating activity variants", () => {
     it("single doc", () => {
         const source = doc as SingleDocSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][] = [];
 
@@ -111,6 +94,8 @@ describe("Test of generating activity variants", () => {
 
     it("sequence with no shuffle", () => {
         const source = seq as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][][] = [];
 
@@ -184,6 +169,8 @@ describe("Test of generating activity variants", () => {
 
     it("sequence with shuffle", () => {
         const source = seqShuf as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][][] = [];
 
@@ -268,6 +255,8 @@ describe("Test of generating activity variants", () => {
 
     it("select single doc", () => {
         const source = sel as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][] = [];
 
@@ -336,6 +325,8 @@ describe("Test of generating activity variants", () => {
 
     it("select multiple from a single doc", () => {
         const source = selMult1doc as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][] = [];
 
@@ -411,6 +402,8 @@ describe("Test of generating activity variants", () => {
 
     it("select multiple from two docs", () => {
         const source = selMult2docs as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][] = [];
 
@@ -492,6 +485,8 @@ describe("Test of generating activity variants", () => {
 
     it("descriptions not shuffled", () => {
         const source = seqWithDes as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][][] = [];
 
@@ -632,6 +627,8 @@ describe("Test of generating activity variants", () => {
 
     it("sequence with selects", () => {
         const source = seq2sel as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][][] = [];
 
@@ -735,6 +732,8 @@ describe("Test of generating activity variants", () => {
 
     it("select from two sequences", () => {
         const source = sel2seq as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants1: number[][][] = [];
         const allQuestionVariants2: number[][][] = [];
@@ -881,6 +880,8 @@ describe("Test of generating activity variants", () => {
 
     it("select multiple from two sequences", () => {
         const source = selMult2seq as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants1: number[][][] = [];
         const allQuestionVariants2: number[][][] = [];
@@ -1063,6 +1064,8 @@ describe("Test of generating activity variants", () => {
 
     it("select single doc, selectByVariant=false", () => {
         const source = selNoVariant as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][][] = [];
         const allQuestions: number[][] = [];
@@ -1149,6 +1152,8 @@ describe("Test of generating activity variants", () => {
 
     it("select multiple from four docs, selectByVariant=false", () => {
         const source = selMult4docsNoVariant as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestions: number[][] = [];
         const allQuestionVariants: number[][][] = [];

--- a/src/test/itemAttempts.test.ts
+++ b/src/test/itemAttempts.test.ts
@@ -8,6 +8,7 @@ import selMult4docsNoVariant from "./testSources/selMult4docsNoVariant.json";
 
 import { SequenceSource, SequenceState } from "../Activity/sequenceState";
 import {
+    gatherDocumentStructure,
     generateNewActivityAttempt,
     generateNewSubActivityAttempt,
     initializeActivityState,
@@ -18,29 +19,11 @@ import {
 } from "../Activity/singleDocState";
 import { SelectSource, SelectState } from "../Activity/selectState";
 
-const numActivityVariants = {
-    doc1: 1,
-    doc2: 2,
-    doc3: 3,
-    doc4: 4,
-    doc5: 5,
-    doc1a: 1,
-    doc3a: 3,
-};
-
-const questionCounts = {
-    doc1: 1,
-    doc2: 1,
-    doc3: 1,
-    doc4: 1,
-    doc5: 1,
-    doc1a: 1,
-    doc3a: 1,
-};
-
 describe("Test of generating new item attempts", () => {
     it("sequence", () => {
         const source = seqShuf as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][][] = [];
 
@@ -125,6 +108,8 @@ describe("Test of generating new item attempts", () => {
 
     it("select multiple from a single doc", () => {
         const source = selMult1doc as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionVariants: number[][] = [];
 
@@ -227,6 +212,8 @@ describe("Test of generating new item attempts", () => {
 
     it("select multiple from two docs", () => {
         const source = selMult2docs as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionIds: string[][] = [];
 
@@ -333,6 +320,8 @@ describe("Test of generating new item attempts", () => {
 
     it("sequence with selects", () => {
         const source = seq2sel as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionIds: string[][][] = [];
 
@@ -430,6 +419,8 @@ describe("Test of generating new item attempts", () => {
 
     it("sequence with selects, combine item and activity attempts", () => {
         const source = seq2sel as SequenceSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionIds: string[][][] = [];
 
@@ -538,6 +529,8 @@ describe("Test of generating new item attempts", () => {
 
     it("select multiple from four docs, selectByVariant=false", () => {
         const source = selMult4docsNoVariant as SelectSource;
+        const { numActivityVariants, questionCounts } =
+            gatherDocumentStructure(source);
 
         const allQuestionIds: string[][] = [];
         const allQuestionVariants: number[][][] = [];

--- a/src/test/testSources/doc.json
+++ b/src/test/testSources/doc.json
@@ -3,5 +3,7 @@
     "type": "singleDoc",
     "isDescription": false,
     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-    "version": "0.7.0-alpha30"
+    "version": "0.7.0-alpha30",
+    "numVariants": 5,
+    "baseLevelComponentCounts": { "problem": 1 }
 }

--- a/src/test/testSources/sel.json
+++ b/src/test/testSources/sel.json
@@ -10,21 +10,27 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": { "question": 1 }
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc4",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         }
     ]
 }

--- a/src/test/testSources/sel2seq.json
+++ b/src/test/testSources/sel2seq.json
@@ -15,14 +15,18 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 4,
+                    "baseLevelComponentCounts": { "problem": 1 }
                 },
                 {
                     "id": "doc5",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 5,
+                    "baseLevelComponentCounts": { "problem": 1 }
                 }
             ]
         },
@@ -36,21 +40,27 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 3,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc2",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 2,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc1",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 1,
+                    "baseLevelComponentCounts": { "question": 1 }
                 }
             ]
         }

--- a/src/test/testSources/selMult1doc.json
+++ b/src/test/testSources/selMult1doc.json
@@ -9,7 +9,9 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         }
     ]
 }

--- a/src/test/testSources/selMult1docNoVariant.json
+++ b/src/test/testSources/selMult1docNoVariant.json
@@ -9,7 +9,9 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         }
     ]
 }

--- a/src/test/testSources/selMult2docs.json
+++ b/src/test/testSources/selMult2docs.json
@@ -9,14 +9,18 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         }
     ]
 }

--- a/src/test/testSources/selMult2seq.json
+++ b/src/test/testSources/selMult2seq.json
@@ -15,14 +15,18 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 4,
+                    "baseLevelComponentCounts": { "problem": 1 }
                 },
                 {
                     "id": "doc5",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 5,
+                    "baseLevelComponentCounts": { "problem": 1 }
                 }
             ]
         },
@@ -36,14 +40,18 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 3,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc2",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 2,
+                    "baseLevelComponentCounts": { "question": 1 }
                 }
             ]
         }

--- a/src/test/testSources/selMult4docsNoVariant.json
+++ b/src/test/testSources/selMult4docsNoVariant.json
@@ -9,28 +9,36 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc1",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": { "question": 1 }
         },
         {
             "id": "doc2",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 2,
+            "baseLevelComponentCounts": { "question": 1 }
         }
     ]
 }

--- a/src/test/testSources/selNoVariant.json
+++ b/src/test/testSources/selNoVariant.json
@@ -10,21 +10,27 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": { "question": 1 }
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc4",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         }
     ]
 }

--- a/src/test/testSources/seq.json
+++ b/src/test/testSources/seq.json
@@ -9,21 +9,27 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc1",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": { "question": 1 }
         }
     ]
 }

--- a/src/test/testSources/seq2sel.json
+++ b/src/test/testSources/seq2sel.json
@@ -15,14 +15,18 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 4,
+                    "baseLevelComponentCounts": { "problem": 1 }
                 },
                 {
                     "id": "doc5",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 5,
+                    "baseLevelComponentCounts": { "problem": 1 }
                 }
             ]
         },
@@ -37,21 +41,27 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 3,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc2",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 2,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc1",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 1,
+                    "baseLevelComponentCounts": { "question": 1 }
                 }
             ]
         }

--- a/src/test/testSources/seqSel0Sel.json
+++ b/src/test/testSources/seqSel0Sel.json
@@ -22,21 +22,27 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 3,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc2",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 2,
+                    "baseLevelComponentCounts": { "question": 1 }
                 },
                 {
                     "id": "doc1",
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30"
+                    "version": "0.7.0-alpha30",
+                    "numVariants": 1,
+                    "baseLevelComponentCounts": { "question": 1 }
                 }
             ]
         }

--- a/src/test/testSources/seqShuf.json
+++ b/src/test/testSources/seqShuf.json
@@ -9,21 +9,27 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": { "question": 1 }
         },
         {
             "id": "doc4",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         }
     ]
 }

--- a/src/test/testSources/seqWithDes.json
+++ b/src/test/testSources/seqWithDes.json
@@ -9,49 +9,63 @@
             "type": "singleDoc",
             "isDescription": true,
             "doenetML": "Title page",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": {}
         },
         {
             "id": "doc4",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 4,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc2",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 2,
+            "baseLevelComponentCounts": { "question": 1 }
         },
         {
             "id": "doc3a",
             "type": "singleDoc",
             "isDescription": true,
             "doenetML": "Intermediate instructions <selectFromSequence length='3' />",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 3,
+            "baseLevelComponentCounts": {}
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 5,
+            "baseLevelComponentCounts": { "problem": 1 }
         },
         {
             "id": "doc1",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 1,
+            "baseLevelComponentCounts": { "question": 1 }
         },
         {
             "id": "doc3",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha30",
+            "numVariants": 3,
+            "baseLevelComponentCounts": { "question": 1 }
         }
     ]
 }


### PR DESCRIPTION
This PR speeds up the initialization of activities, by assuming that the document structure is already saved in the source and doesn't need to be calculated.

This avoids the need to create an activity and a web-worker for each single document in the source. Now we create an activity only for the activities that will be rendered.