### PR TITLE
Add onSubmission flag to exported activity state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha2",
+    "version": "0.1.0-alpha4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha2",
+            "version": "0.1.0-alpha4",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@doenet/doenetml-iframe": "^0.7.0-alpha30",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha2",
+    "version": "0.1.0-alpha4",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -73,6 +73,7 @@ export type ActivityStateNoSource =
 export type ExportedActivityState = {
     state: ActivityStateNoSource;
     sourceHash: string;
+    onSubmission?: boolean;
 };
 
 // Type guards
@@ -104,7 +105,9 @@ export function isExportedActivityState(
         typedObj !== null &&
         typeof typedObj === "object" &&
         isActivityStateNoSource(typedObj.state) &&
-        typeof typedObj.sourceHash === "string"
+        typeof typedObj.sourceHash === "string" &&
+        (typedObj.onSubmission === undefined ||
+            typeof typedObj.onSubmission === "boolean")
     );
 }
 

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -141,6 +141,17 @@ export function activityStateReducer(
 
                 const sourceHash = hash(newActivityState.source);
 
+                let onSubmission = false;
+                const doenetState = action.doenetState;
+                if (
+                    typeof doenetState === "object" &&
+                    doenetState !== null &&
+                    "onSubmission" in doenetState &&
+                    typeof doenetState.onSubmission === "boolean"
+                ) {
+                    onSubmission = doenetState.onSubmission;
+                }
+
                 window.postMessage({
                     state: {
                         state: pruneActivityStateForSave(
@@ -148,6 +159,7 @@ export function activityStateReducer(
                             false,
                         ),
                         sourceHash,
+                        onSubmission,
                     },
                     score: newActivityState.creditAchieved,
                     scoreByItem,


### PR DESCRIPTION
This PR modifies the state returned by `reportScoreAndState` to include the `onSubmission` flag received from the `DoenetViewer` state that initiated the save event.