### PR TITLE
don't save activity attempts

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from "react";
 import { ActivityViewer } from "../src/activity-viewer";
 import activitySource from "./testActivity.json";
 
-import initialAssignmentState from "./testInitialState.json";
+// import initialAssignmentState from "./testInitialState.json";
+const initialAssignmentState = null;
 import {
     ExportedActivityState,
     isActivitySource,
@@ -224,7 +225,7 @@ function App() {
 
     const [_score, setScore] = useState(0);
     const [scoreByItem, setScoreByItem] = useState<
-        { id: string; score: number }[]
+        { id: string; score: number; maxScore: number; docId?: string }[]
     >([]);
 
     useEffect(() => {
@@ -307,7 +308,7 @@ function App() {
 
                 <div>
                     Assignment credit:{" "}
-                    {(activityState?.state.creditAchieved ?? 0) * 100}%
+                    {(activityState?.state.maxCreditAchieved ?? 0) * 100}%
                 </div>
                 <div>
                     Credit by item, latest attempt:

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -319,7 +319,7 @@ function App() {
                 </div>
                 <div>
                     Assignment attempt number:{" "}
-                    {activityState?.state.attempts.length ?? 0 + 1}
+                    {activityState?.state.attemptNumber ?? 0 + 1}
                 </div>
             </div>
 

--- a/dev/testInitialState.json
+++ b/dev/testInitialState.json
@@ -5,14 +5,14 @@
         "parentId": null,
         "initialVariant": 445663,
         "creditAchieved": 0.5,
-        "latestChildStates": [
+        "allChildren": [
             {
                 "type": "select",
                 "id": "sel",
                 "parentId": "seq",
                 "initialVariant": 144857,
                 "creditAchieved": 0,
-                "latestChildStates": [
+                "allChildren": [
                     {
                         "type": "singleDoc",
                         "id": "qrf",
@@ -67,7 +67,7 @@
                 "parentId": "seq",
                 "initialVariant": 283829,
                 "creditAchieved": 1,
-                "latestChildStates": [
+                "allChildren": [
                     {
                         "type": "singleDoc",
                         "id": "sel2a",
@@ -142,7 +142,7 @@
                         "parentId": "seq",
                         "initialVariant": 144857,
                         "creditAchieved": 0,
-                        "latestChildStates": [
+                        "allChildren": [
                             {
                                 "type": "singleDoc",
                                 "id": "qrf",
@@ -197,7 +197,7 @@
                         "parentId": "seq",
                         "initialVariant": 283829,
                         "creditAchieved": 1,
-                        "latestChildStates": [
+                        "allChildren": [
                             {
                                 "type": "singleDoc",
                                 "id": "sel2a",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha4",
+    "version": "0.1.0-alpha5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha4",
+            "version": "0.1.0-alpha5",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@doenet/doenetml-iframe": "^0.7.0-alpha30",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha4",
+    "version": "0.1.0-alpha5",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -46,54 +46,38 @@ export function SelectActivity({
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
 }) {
-    const latestAttempt =
-        state.attempts.length > 0
-            ? state.attempts[state.attempts.length - 1]
-            : null;
-
     const selectedActivities: ReactElement[] = [];
     const selectedIds: string[] = [];
 
-    if (latestAttempt) {
-        for (const activity of latestAttempt.activities) {
-            selectedActivities.push(
-                <Activity
-                    key={activity.id}
-                    state={activity}
-                    flags={flags}
-                    baseId={baseId}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    linkSettings={linkSettings}
-                    darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    checkRender={checkRender}
-                    checkHidden={checkHidden}
-                    allowItemAttemptButtons={allowItemAttemptButtons}
-                    generateNewItemAttempt={generateNewItemAttempt}
-                    hasRenderedCallback={hasRenderedCallback}
-                    reportVisibility={reportVisibility}
-                    reportVisibilityCallback={reportVisibilityCallback}
-                />,
-            );
-            selectedIds.push(activity.id);
-        }
+    for (const activity of state.selectedChildren) {
+        selectedActivities.push(
+            <Activity
+                key={activity.id}
+                state={activity}
+                flags={flags}
+                baseId={baseId}
+                forceDisable={forceDisable}
+                forceShowCorrectness={forceShowCorrectness}
+                forceShowSolution={forceShowSolution}
+                forceUnsuppressCheckwork={forceUnsuppressCheckwork}
+                linkSettings={linkSettings}
+                darkMode={darkMode}
+                showAnswerTitles={showAnswerTitles}
+                reportScoreAndStateCallback={reportScoreAndStateCallback}
+                checkRender={checkRender}
+                checkHidden={checkHidden}
+                allowItemAttemptButtons={allowItemAttemptButtons}
+                generateNewItemAttempt={generateNewItemAttempt}
+                hasRenderedCallback={hasRenderedCallback}
+                reportVisibility={reportVisibility}
+                reportVisibilityCallback={reportVisibilityCallback}
+            />,
+        );
+        selectedIds.push(activity.id);
     }
 
     return (
-        <div
-            key={
-                // Replace the activity in the DOM when a new attempt is created,
-                // except preserve it if just a single item was replaced with the other items staying unchanged.
-                state.attempts.filter(
-                    (x) => x.singleItemReplacementIdx === undefined,
-                ).length
-            }
-            hidden={!checkRender(state)}
-        >
+        <div key={state.attemptNumber} hidden={!checkRender(state)}>
             <div>{selectedActivities}</div>
         </div>
     );

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -46,43 +46,36 @@ export function SequenceActivity({
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
 }) {
-    const latestAttempt =
-        state.attempts.length > 0
-            ? state.attempts[state.attempts.length - 1]
-            : null;
-
     const activityList: ReactElement[] = [];
 
-    if (latestAttempt) {
-        for (const activity of latestAttempt.activities) {
-            activityList.push(
-                <Activity
-                    key={activity.id}
-                    state={activity}
-                    flags={flags}
-                    baseId={baseId}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    linkSettings={linkSettings}
-                    darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    checkRender={checkRender}
-                    checkHidden={checkHidden}
-                    allowItemAttemptButtons={allowItemAttemptButtons}
-                    generateNewItemAttempt={generateNewItemAttempt}
-                    hasRenderedCallback={hasRenderedCallback}
-                    reportVisibility={reportVisibility}
-                    reportVisibilityCallback={reportVisibilityCallback}
-                />,
-            );
-        }
+    for (const activity of state.orderedChildren) {
+        activityList.push(
+            <Activity
+                key={activity.id}
+                state={activity}
+                flags={flags}
+                baseId={baseId}
+                forceDisable={forceDisable}
+                forceShowCorrectness={forceShowCorrectness}
+                forceShowSolution={forceShowSolution}
+                forceUnsuppressCheckwork={forceUnsuppressCheckwork}
+                linkSettings={linkSettings}
+                darkMode={darkMode}
+                showAnswerTitles={showAnswerTitles}
+                reportScoreAndStateCallback={reportScoreAndStateCallback}
+                checkRender={checkRender}
+                checkHidden={checkHidden}
+                allowItemAttemptButtons={allowItemAttemptButtons}
+                generateNewItemAttempt={generateNewItemAttempt}
+                hasRenderedCallback={hasRenderedCallback}
+                reportVisibility={reportVisibility}
+                reportVisibilityCallback={reportVisibilityCallback}
+            />,
+        );
     }
 
     return (
-        <div hidden={!checkRender(state)} key={state.attempts.length}>
+        <div hidden={!checkRender(state)} key={state.attemptNumber}>
             {activityList}
         </div>
     );

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -48,24 +48,17 @@ export function SingleDocActivity({
 }) {
     const [rendered, setRendered] = useState(false);
 
-    const latestAttempt =
-        state.attempts.length > 0
-            ? state.attempts[state.attempts.length - 1]
-            : null;
-
-    const [attemptNumber, setAttemptNumber] = useState(state.attempts.length);
+    const [attemptNumber, setAttemptNumber] = useState(state.attemptNumber);
     const [initialDoenetState, setInitialDoenetState] = useState<Record<
         string,
         unknown
     > | null>(
-        latestAttempt
-            ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (latestAttempt.doenetState as Record<string, any> | null)
-            : null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        state.doenetState as Record<string, any> | null,
     );
 
     const [requestedVariantIndex, setRequestedVariantIndex] = useState(
-        latestAttempt ? latestAttempt.variant : state.initialVariant,
+        state.currentVariant,
     );
 
     const ref = useRef<HTMLDivElement>(null);
@@ -90,28 +83,22 @@ export function SingleDocActivity({
     // Note: given the way the `<DoenetViewer>` iframe is set up, any changes in props
     // will reinitialize the activity. Hence, we make sure that no props change
     // unless the attempt number has changed.
-    if (state.attempts.length !== attemptNumber) {
-        setAttemptNumber(state.attempts.length);
+    if (state.attemptNumber !== attemptNumber) {
+        setAttemptNumber(state.attemptNumber);
 
         setInitialDoenetState(
-            latestAttempt
-                ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (latestAttempt.doenetState as Record<string, any> | null)
-                : null,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            state.doenetState as Record<string, any> | null,
         );
 
-        setRequestedVariantIndex(
-            latestAttempt ? latestAttempt.variant : state.initialVariant,
-        );
+        setRequestedVariantIndex(state.currentVariant);
     }
 
-    const initialCounters = latestAttempt
-        ? {
-              question: latestAttempt.initialQuestionCounter,
-              problem: latestAttempt.initialQuestionCounter,
-              exercise: latestAttempt.initialQuestionCounter,
-          }
-        : undefined;
+    const initialCounters = {
+        question: state.initialQuestionCounter,
+        problem: state.initialQuestionCounter,
+        exercise: state.initialQuestionCounter,
+    };
 
     const source = state.source;
 
@@ -127,7 +114,7 @@ export function SingleDocActivity({
         <div ref={ref}>
             <div hidden={!render || hidden} style={{ minHeight: "100px" }}>
                 <DoenetViewer
-                    key={state.attempts.length}
+                    key={state.attemptNumber}
                     doenetML={source.doenetML}
                     doenetmlVersion={source.version}
                     render={render}
@@ -158,7 +145,7 @@ export function SingleDocActivity({
                         onClick={() => {
                             generateNewItemAttempt(
                                 state.id,
-                                latestAttempt?.initialQuestionCounter ?? 1,
+                                state.initialQuestionCounter,
                             );
                         }}
                         style={{

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -114,7 +114,7 @@ export function isExportedActivityState(
 /**
  * Initialize activity state from `source` so that it is ready to generate attempts.
  *
- * Populates all the activities through the `latestChildStates` field.
+ * Populates all the activities through the `allChildren` field.
  * Result is based on `numActivityVariants`,
  * which stores of the number of variants calculated for each single doc activity.
  *
@@ -189,14 +189,12 @@ export function generateNewActivityAttempt({
     initialQuestionCounter,
     questionCounts,
     parentAttempt,
-    resetCredit = false,
 }: {
     state: ActivityState;
     numActivityVariants: ActivityVariantRecord;
     initialQuestionCounter: number;
     questionCounts: QuestionCountRecord;
     parentAttempt: number;
-    resetCredit?: boolean;
 }): { finalQuestionCounter: number; state: ActivityState } {
     switch (state.type) {
         case "singleDoc": {
@@ -206,7 +204,6 @@ export function generateNewActivityAttempt({
                 initialQuestionCounter,
                 questionCounts,
                 parentAttempt,
-                resetCredit,
             });
         }
         case "select": {
@@ -216,7 +213,6 @@ export function generateNewActivityAttempt({
                 initialQuestionCounter,
                 questionCounts,
                 parentAttempt,
-                resetCredit,
             });
         }
         case "sequence": {
@@ -226,7 +222,6 @@ export function generateNewActivityAttempt({
                 initialQuestionCounter,
                 questionCounts,
                 parentAttempt,
-                resetCredit,
             });
         }
     }
@@ -245,14 +240,12 @@ export function generateNewSubActivityAttempt({
     numActivityVariants,
     initialQuestionCounter,
     questionCounts,
-    resetCredit = false,
 }: {
     id: string;
     state: ActivityState;
     numActivityVariants: ActivityVariantRecord;
     initialQuestionCounter: number;
     questionCounts: QuestionCountRecord;
-    resetCredit?: boolean;
 }): ActivityState {
     if (id === state.id) {
         // `id` does not correspond to a sub-activity, so generate full activity state
@@ -262,7 +255,6 @@ export function generateNewSubActivityAttempt({
             initialQuestionCounter,
             questionCounts,
             parentAttempt: 1,
-            resetCredit,
         });
         return newActivityState;
     }
@@ -283,12 +275,10 @@ export function generateNewSubActivityAttempt({
     if (
         subActivityState.type === "singleDoc" &&
         parentState.type === "select" &&
-        parentState.latestChildStates.every(
-            (child) => child.type === "singleDoc",
-        )
+        parentState.allChildren.every((child) => child.type === "singleDoc")
     ) {
         const grandParentAttempt = parentState.parentId
-            ? allStates[parentState.parentId].attempts.length
+            ? allStates[parentState.parentId].attemptNumber
             : 1;
 
         let newParentState: ActivityState;
@@ -304,6 +294,8 @@ export function generateNewSubActivityAttempt({
                     parentAttempt: grandParentAttempt,
                     childId: id,
                 }));
+
+            // Note: generateNewSingleDocAttemptForMultiSelect already preserves credit achieved
         } else {
             // for a select-one, just generate a new attempt of the select (rather than the single doc)
             // so that we pick a new single doc child rather than just a new variant of the original single doc
@@ -314,6 +306,10 @@ export function generateNewSubActivityAttempt({
                 questionCounts,
                 parentAttempt: grandParentAttempt,
             }));
+
+            // preserve the old credit achieved
+            newParentState.creditAchieved =
+                allStates[parentState.id].creditAchieved;
         }
 
         allStates[parentState.id] = newParentState;
@@ -328,8 +324,11 @@ export function generateNewSubActivityAttempt({
             numActivityVariants,
             initialQuestionCounter,
             questionCounts,
-            parentAttempt: parentState.attempts.length,
+            parentAttempt: parentState.attemptNumber,
         });
+
+        // preserve the old credit achieved
+        newSubActivityState.creditAchieved = allStates[id].creditAchieved;
 
         allStates[id] = newSubActivityState;
 
@@ -347,7 +346,7 @@ export function generateNewSubActivityAttempt({
  */
 export function extractActivityItemCredit(
     activityState: ActivityState,
-): { id: string; score: number }[] {
+): { id: string; score: number; latestScore: number; docId?: string }[] {
     switch (activityState.type) {
         case "singleDoc": {
             return extractSingleDocItemCredit(activityState);
@@ -368,7 +367,7 @@ export function extractActivityItemCredit(
  * If `clearDoenetState` is `true`, then also remove the `doenetState` in single documents.
  *
  * Even if `clearDoenetState` is `false``, still clear `doenetState` on all but the latest attempt
- * and clear it on all `latestChildStates`. In this way, the (potentially large) DoenetML state is saved
+ * and clear it on all `allChildren`. In this way, the (potentially large) DoenetML state is saved
  * only where needed to reconstitute the activity state.
  */
 export function pruneActivityStateForSave(
@@ -435,12 +434,12 @@ export function getItemSequence(state: ActivityState): string[] {
     if (state.type === "singleDoc") {
         return [state.id];
     } else {
-        const numAttempts = state.attempts.length;
+        const numAttempts = state.attemptNumber;
         if (numAttempts === 0) {
-            if (state.latestChildStates.length === 0) {
+            if (state.allChildren.length === 0) {
                 return [];
             } else {
-                const prelimResult = state.latestChildStates.flatMap((a) =>
+                const prelimResult = state.allChildren.flatMap((a) =>
                     getItemSequence(a),
                 );
                 if (state.type === "sequence") {
@@ -450,9 +449,11 @@ export function getItemSequence(state: ActivityState): string[] {
                 }
             }
         }
-        return state.attempts[numAttempts - 1].activities.flatMap((a) =>
-            getItemSequence(a),
-        );
+        if (state.type === "sequence") {
+            return state.orderedChildren.flatMap((a) => getItemSequence(a));
+        } else {
+            return state.selectedChildren.flatMap((a) => getItemSequence(a));
+        }
     }
 }
 
@@ -588,7 +589,7 @@ export function gatherStates(
     };
 
     if (state.type !== "singleDoc") {
-        for (const child of state.latestChildStates) {
+        for (const child of state.allChildren) {
             Object.assign(allStates, gatherStates(child));
         }
     }
@@ -599,7 +600,7 @@ export function gatherStates(
 /**
  * Given the changed state of activity with `id`, as stored in `allStates[id]`,
  * propagate the change to the activities ancestors, updating their
- * `latestChidStates`, `attempts`, and `creditAchieved` fields.
+ * `latestChidStates`, `attempts`, `latestCreditAchieved` and `creditAchieved` fields.
  *
  * Creates new state objects via shallow copies (and does not modify existing state objects),
  * adding the new state objects back to `allStates`.
@@ -627,42 +628,39 @@ export function propagateStateChangeToRoot({
         throw Error("Single doc activity cannot be a parent");
     }
 
-    const childIdx = newParentState.latestChildStates
+    const childIdx = newParentState.allChildren
         .map((child) => child.id)
         .indexOf(id);
 
     if (childIdx === -1) {
         throw Error("Something went wrong as parent didn't have child.");
     } else {
-        newParentState.latestChildStates = [
-            ...newParentState.latestChildStates,
-        ];
-        newParentState.latestChildStates[childIdx] = activityState;
+        newParentState.allChildren = [...newParentState.allChildren];
+        newParentState.allChildren[childIdx] = activityState;
     }
 
-    newParentState.attempts = [...newParentState.attempts];
-    const numAttempts = newParentState.attempts.length;
-    const lastAttempt = (newParentState.attempts[numAttempts - 1] = {
-        ...newParentState.attempts[numAttempts - 1],
-    });
+    const childActivities =
+        newParentState.type === "sequence"
+            ? [...newParentState.orderedChildren]
+            : [...newParentState.selectedChildren];
 
-    const childIdx2 = lastAttempt.activities
-        .map((child) => child.id)
-        .indexOf(id);
+    const childIdx2 = childActivities.map((child) => child.id).indexOf(id);
     if (childIdx2 === -1) {
         throw Error(
             "Something went wrong as parent didn't have child in last attempt.",
         );
     }
 
-    lastAttempt.activities = [...lastAttempt.activities];
-    lastAttempt.activities[childIdx2] = activityState;
+    childActivities[childIdx2] = activityState;
 
     let credit: number;
+    let latestCredit: number;
 
     if (newParentState.type === "sequence") {
+        newParentState.orderedChildren = childActivities;
+
         // calculate credit only from non-descriptions
-        const nonDescriptions = newParentState.latestChildStates.filter(
+        const nonDescriptions = newParentState.allChildren.filter(
             (activityState) =>
                 activityState.type !== "singleDoc" ||
                 !activityState.source.isDescription,
@@ -685,19 +683,27 @@ export function propagateStateChangeToRoot({
             (a, c, i) => a + c.creditAchieved * creditWeights[i],
             0,
         );
+        latestCredit = nonDescriptions.reduce(
+            (a, c, i) => a + c.latestCreditAchieved * creditWeights[i],
+            0,
+        );
     } else {
+        newParentState.selectedChildren = childActivities;
+
         // select: take average of credit from all last attempt activities
         credit =
-            lastAttempt.activities.reduce((a, c) => a + c.creditAchieved, 0) /
-            lastAttempt.activities.length;
+            childActivities.reduce((a, c) => a + c.creditAchieved, 0) /
+            childActivities.length;
+        latestCredit =
+            childActivities.reduce((a, c) => a + c.latestCreditAchieved, 0) /
+            childActivities.length;
     }
-
-    lastAttempt.creditAchieved = Math.max(lastAttempt.creditAchieved, credit);
 
     newParentState.creditAchieved = Math.max(
         newParentState.creditAchieved,
         credit,
     );
+    newParentState.latestCreditAchieved = latestCredit;
 
     return propagateStateChangeToRoot({
         allStates,

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -69,7 +69,7 @@ export function activityStateReducer(
                 const scoreByItem = extractActivityItemCredit(action.state);
                 window.postMessage({
                     score: action.state.creditAchieved,
-                    latestScore: action.state.latestCreditAchieved,
+                    maxScore: action.state.maxCreditAchieved,
                     scoreByItem,
                     subject: "SPLICE.reportScoreByItem",
                     activityId: action.baseId,
@@ -109,7 +109,7 @@ export function activityStateReducer(
                     // Just send score by item to indicate how many items are in the activity
                     window.postMessage({
                         score: newActivityState.creditAchieved,
-                        latestScore: newActivityState.latestCreditAchieved,
+                        maxScore: newActivityState.maxCreditAchieved,
                         scoreByItem,
                         subject: "SPLICE.reportScoreByItem",
                         activityId: action.baseId,
@@ -126,7 +126,7 @@ export function activityStateReducer(
                             sourceHash,
                         },
                         score: newActivityState.creditAchieved,
-                        latestScore: newActivityState.latestCreditAchieved,
+                        maxScore: newActivityState.maxCreditAchieved,
                         scoreByItem,
                         subject: "SPLICE.reportScoreAndState",
                         activityId: action.baseId,
@@ -165,7 +165,7 @@ export function activityStateReducer(
                         onSubmission,
                     },
                     score: newActivityState.creditAchieved,
-                    latestScore: newActivityState.latestCreditAchieved,
+                    maxScore: newActivityState.maxCreditAchieved,
                     scoreByItem,
                     subject: "SPLICE.reportScoreAndState",
                     activityId: action.baseId,
@@ -200,11 +200,11 @@ function updateSingleDocState(
         );
     }
 
-    newSingleDocState.creditAchieved = Math.max(
-        newSingleDocState.creditAchieved,
+    newSingleDocState.creditAchieved = action.creditAchieved;
+    newSingleDocState.maxCreditAchieved = Math.max(
+        newSingleDocState.maxCreditAchieved,
         action.creditAchieved,
     );
-    newSingleDocState.latestCreditAchieved = action.creditAchieved;
 
     newSingleDocState.doenetState = action.doenetState;
 

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -1,5 +1,6 @@
 import {
     ActivityVariantRecord,
+    isRestrictToVariantSlice,
     QuestionCountRecord,
     RestrictToVariantSlice,
 } from "../types";
@@ -52,27 +53,20 @@ export type SelectState = {
     initialVariant: number;
     /** Credit achieved (between 0 and 1) over all attempts of this activity */
     creditAchieved: number;
-    /** The latest state of all possible activities that could be selected from. */
-    latestChildStates: ActivityState[];
-    attempts: SelectAttemptState[];
-    /** See {@link RestrictToVariantSlice} */
-    restrictToVariantSlice?: RestrictToVariantSlice;
-};
-
-/** The state of an attempt of a select activity. */
-export type SelectAttemptState = {
-    /** The activities that were selected for this attempt */
-    activities: ActivityState[];
-    /** Credit achieved (between 0 and 1) on this attempt */
-    creditAchieved: number;
+    /** Credit achieved from the latest submission */
+    latestCreditAchieved: number;
+    /** The state of all possible activities that could be selected from. */
+    allChildren: ActivityState[];
+    /** The number of the current attempt */
+    attemptNumber: number;
+    /** The children selected for the current attempt  */
+    selectedChildren: ActivityState[];
+    /** A list of the the ids of the children selected in all attempts, ordered by attempt number */
+    previousSelections: string[];
     /** The value of the question counter set for the beginning of this activity */
     initialQuestionCounter: number;
-    /**
-     * If `numToSelect` > 1 and a new attempt was created (via `generateNewSingleDocAttemptForMultiSelect`)
-     * that replaced just one item and left the others unchanged,
-     * then `singleItemReplacementIdx` gives the index of that one item that was replaced.
-     */
-    singleItemReplacementIdx?: number;
+    /** See {@link RestrictToVariantSlice} */
+    restrictToVariantSlice?: RestrictToVariantSlice;
 };
 
 /**
@@ -82,15 +76,10 @@ export type SelectAttemptState = {
  */
 export type SelectStateNoSource = Omit<
     SelectState,
-    "source" | "latestChildStates" | "attempts"
+    "source" | "allChildren" | "selectedChildren"
 > & {
-    latestChildStates: ActivityStateNoSource[];
-    attempts: {
-        activities: ActivityStateNoSource[];
-        creditAchieved: number;
-        initialQuestionCounter: number;
-        singleItemReplacementIdx?: number;
-    }[];
+    allChildren: ActivityStateNoSource[];
+    selectedChildren: ActivityStateNoSource[];
 };
 
 // type guards
@@ -124,18 +113,17 @@ export function isSelectState(obj: unknown): obj is SelectState {
         isSelectSource(typedObj.source) &&
         typeof typedObj.initialVariant === "number" &&
         typeof typedObj.creditAchieved === "number" &&
-        Array.isArray(typedObj.latestChildStates) &&
-        typedObj.latestChildStates.every(isActivityState) &&
-        Array.isArray(typedObj.attempts) &&
-        typedObj.attempts.every(
-            (attempt) =>
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                attempt !== null &&
-                typeof attempt === "object" &&
-                typeof attempt.creditAchieved === "number" &&
-                Array.isArray(attempt.activities) &&
-                attempt.activities.every(isActivityState),
-        )
+        typeof typedObj.latestCreditAchieved === "number" &&
+        Array.isArray(typedObj.allChildren) &&
+        typedObj.allChildren.every(isActivityState) &&
+        typeof typedObj.attemptNumber === "number" &&
+        Array.isArray(typedObj.selectedChildren) &&
+        typedObj.selectedChildren.every(isActivityState) &&
+        Array.isArray(typedObj.previousSelections) &&
+        typedObj.previousSelections.every((x) => typeof x === "string") &&
+        typeof typedObj.initialQuestionCounter === "number" &&
+        (typedObj.restrictToVariantSlice === undefined ||
+            isRestrictToVariantSlice(typedObj.restrictToVariantSlice))
     );
 }
 
@@ -153,25 +141,24 @@ export function isSelectStateNoSource(
         (typedObj.parentId === null || typeof typedObj.parentId === "string") &&
         typeof typedObj.initialVariant === "number" &&
         typeof typedObj.creditAchieved === "number" &&
-        Array.isArray(typedObj.latestChildStates) &&
-        typedObj.latestChildStates.every(isActivityStateNoSource) &&
-        Array.isArray(typedObj.attempts) &&
-        typedObj.attempts.every(
-            (attempt) =>
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                attempt !== null &&
-                typeof attempt === "object" &&
-                typeof attempt.creditAchieved === "number" &&
-                Array.isArray(attempt.activities) &&
-                attempt.activities.every(isActivityStateNoSource),
-        )
+        typeof typedObj.latestCreditAchieved === "number" &&
+        Array.isArray(typedObj.allChildren) &&
+        typedObj.allChildren.every(isActivityStateNoSource) &&
+        typeof typedObj.attemptNumber === "number" &&
+        Array.isArray(typedObj.selectedChildren) &&
+        typedObj.selectedChildren.every(isActivityStateNoSource) &&
+        Array.isArray(typedObj.previousSelections) &&
+        typedObj.previousSelections.every((x) => typeof x === "string") &&
+        typeof typedObj.initialQuestionCounter === "number" &&
+        (typedObj.restrictToVariantSlice === undefined ||
+            isRestrictToVariantSlice(typedObj.restrictToVariantSlice))
     );
 }
 
 /**
  * Initialize activity state from `source` so that it is ready to generate attempts.
  *
- * Populates all the activities through the `latestChildStates` field,
+ * Populates all the activities through the `allChildren` field,
  * similar to the behavior of `getUninitializedActivityState`,
  * only this time it takes advantage of `numActivityVariants`,
  * which stores of the number of variants calculated for each single doc activity.
@@ -269,8 +256,12 @@ export function initializeSelectState({
         source,
         initialVariant: variant,
         creditAchieved: 0,
-        latestChildStates: childStates,
-        attempts: [],
+        latestCreditAchieved: 0,
+        allChildren: childStates,
+        attemptNumber: 0,
+        selectedChildren: [],
+        previousSelections: [],
+        initialQuestionCounter: 0,
         restrictToVariantSlice,
     };
 }
@@ -278,7 +269,7 @@ export function initializeSelectState({
 /**
  * Generate a new attempt for the base activity of `state`, recursing to child activities.
  *
- * For each attempt, a set of children from `state.latestChildStates` of size `state.source.numToSelect`
+ * For each attempt, a set of children from `state.allChildren` of size `state.source.numToSelect`
  * is selected. If `state.source.selectByVariant` is `true`, then the selection probability of each
  * child is weighted by its number of variants, and a child may be selected multiple times (but with different variants).
  *
@@ -294,18 +285,16 @@ export function generateNewSelectAttempt({
     initialQuestionCounter,
     questionCounts,
     parentAttempt,
-    resetCredit = false,
 }: {
     state: SelectState;
     numActivityVariants: ActivityVariantRecord;
     initialQuestionCounter: number;
     questionCounts: QuestionCountRecord;
     parentAttempt: number;
-    resetCredit?: boolean;
 }): { finalQuestionCounter: number; state: SelectState } {
     const source = state.source;
     const numToSelect = source.numToSelect;
-    const numChildren = state.latestChildStates.length;
+    const numChildren = state.allChildren.length;
 
     if (numChildren === 0) {
         return { finalQuestionCounter: initialQuestionCounter, state };
@@ -314,7 +303,7 @@ export function generateNewSelectAttempt({
     // If the child's variants have already been broken up into slices via `initializeSelectState`, above,
     // this calculation based on activity state will take that into account.
     // In particular, if `numToSelect` > 1, each child should report just one variant.
-    const numVariantsPerChild = state.latestChildStates.map((a) =>
+    const numVariantsPerChild = state.allChildren.map((a) =>
         calcNumVariantsFromState(a, numActivityVariants),
     );
 
@@ -347,7 +336,7 @@ export function generateNewSelectAttempt({
     }
 
     const childIdToIdx: Record<string, number> = {};
-    for (const [idx, child] of state.latestChildStates.entries()) {
+    for (const [idx, child] of state.allChildren.entries()) {
         childIdToIdx[child.id] = idx;
     }
 
@@ -368,7 +357,7 @@ export function generateNewSelectAttempt({
     // and the child activity has access to more information to select the variants.
 
     // total number of options selected in previous attempts
-    const numPrevSelected = numToSelect * state.attempts.length;
+    const numPrevSelected = numToSelect * state.attemptNumber;
 
     // The total number of options selected so far in our current group of size `totalNumOptions`
     const numInGroup = numPrevSelected % totalNumOptions;
@@ -378,8 +367,7 @@ export function generateNewSelectAttempt({
     // Go back to the previous `numInGroup` children
     // and count how many times each child has already been selected
     const childCountsInGroup = Array<number>(numChildren).fill(0);
-    for (const childId of state.attempts
-        .flatMap((attempt) => attempt.activities.map((activity) => activity.id))
+    for (const childId of [...state.previousSelections]
         .reverse()
         .slice(0, numInGroup)) {
         childCountsInGroup[childIdToIdx[childId]]++;
@@ -408,7 +396,7 @@ export function generateNewSelectAttempt({
         "|" +
         state.id.toString() +
         "|" +
-        state.attempts.length.toString() +
+        state.attemptNumber.toString() +
         "|" +
         parentAttempt.toString();
 
@@ -455,7 +443,7 @@ export function generateNewSelectAttempt({
     // storing the state representing this attempt in `newActivityOptionStates`,
     // and appending the state to `newActivityStates`.
     const newActivityStates: ActivityState[] = [];
-    const newActivityOptionStates = [...state.latestChildStates];
+    const newActivityOptionStates = [...state.allChildren];
     let questionCounter = initialQuestionCounter;
 
     for (const childIdx of childrenChosen) {
@@ -465,8 +453,7 @@ export function generateNewSelectAttempt({
                 numActivityVariants,
                 initialQuestionCounter: questionCounter,
                 questionCounts,
-                parentAttempt: state.attempts.length + 1,
-                resetCredit: true,
+                parentAttempt: state.attemptNumber + 1,
             });
         questionCounter = endCounter;
 
@@ -475,22 +462,19 @@ export function generateNewSelectAttempt({
         newActivityStates.push(newState);
     }
 
-    const newAttemptState: SelectAttemptState = {
-        activities: newActivityStates,
-        creditAchieved: 0,
-        initialQuestionCounter,
-    };
-
     const newState: SelectState = {
         ...state,
-        latestChildStates: newActivityOptionStates,
+        creditAchieved: 0,
+        latestCreditAchieved: 0,
+        allChildren: newActivityOptionStates,
+        attemptNumber: state.attemptNumber + 1,
+        selectedChildren: newActivityStates,
+        previousSelections: [
+            ...state.previousSelections,
+            ...newActivityStates.map((s) => s.id),
+        ],
+        initialQuestionCounter,
     };
-
-    newState.attempts = [...newState.attempts, newAttemptState];
-
-    if (resetCredit) {
-        newState.creditAchieved = 0;
-    }
 
     return { finalQuestionCounter: questionCounter, state: newState };
 }
@@ -517,16 +501,16 @@ export function generateNewSingleDocAttemptForMultiSelect({
     const source = state.source;
     const numToSelect = source.numToSelect;
 
-    if (numToSelect === 1 || state.attempts.length === 0) {
+    if (numToSelect === 1 || state.attemptNumber === 0) {
         throw Error(
             "no reason to call when selecting just one item or for first attempt",
         );
     }
 
-    const numChildren = state.latestChildStates.length;
+    const numChildren = state.allChildren.length;
 
     const childIdToIdx: Record<string, number> = {};
-    for (const [idx, child] of state.latestChildStates.entries()) {
+    for (const [idx, child] of state.allChildren.entries()) {
         childIdToIdx[child.id] = idx;
     }
 
@@ -538,8 +522,7 @@ export function generateNewSingleDocAttemptForMultiSelect({
     //    including previous replacements of other children and entire attempts via `generateNewSelectAttempt`.
 
     // First, we exclude all the currently selected sources for this attempt
-    const lastAttempt = state.attempts[state.attempts.length - 1];
-    const otherSelectedIds = lastAttempt.activities
+    const otherSelectedIds = state.selectedChildren
         .filter((a) => a.id !== childId)
         .map((a) => a.id);
 
@@ -548,7 +531,7 @@ export function generateNewSingleDocAttemptForMultiSelect({
     }
 
     // We'll select from all the other ids (which includes this child's id)
-    const idOptions = state.latestChildStates
+    const idOptions = state.allChildren
         .map((s) => s.id)
         .filter((id) => !otherSelectedIds.includes(id));
     const numOptions = idOptions.length;
@@ -557,25 +540,9 @@ export function generateNewSingleDocAttemptForMultiSelect({
     // We create a list of when these ids were selected, create groups of `numOptions`,
     // and exclude those id's that are in our current group.
     // (We don't worry that the current group might have duplicate ids.)
-    const prevSelectionOfOptions = state.attempts.flatMap((attempt) => {
-        if (attempt.singleItemReplacementIdx === undefined) {
-            // This attempt was from `generateNewSelectAttempt`, so count all items.
-            return attempt.activities
-                .map((activity) => activity.id)
-                .filter((id) => !otherSelectedIds.includes(id));
-        } else {
-            // This attempt replaced a single item,
-            // (i.e., was a previous call to `generateNewSingleDocAttemptForMultiSelect`)
-            // sp only count that item that was changed
-            const changedId =
-                attempt.activities[attempt.singleItemReplacementIdx].id;
-            if (otherSelectedIds.includes(changedId)) {
-                return [];
-            } else {
-                return [changedId];
-            }
-        }
-    });
+    const prevSelectionOfOptions = state.previousSelections.filter(
+        (id) => !otherSelectedIds.includes(id),
+    );
 
     const numPrevSelections = prevSelectionOfOptions.length;
     const numInGroup = numPrevSelections % numOptions;
@@ -585,20 +552,20 @@ export function generateNewSingleDocAttemptForMultiSelect({
     );
 
     // The complete list of all the activities were are excluding from selection,
-    // represented by their index into `latestChildStates`
+    // represented by their index into `allChildren`
     const idxOfAllExcluded = [...otherSelectedIds, ...additionalExcludes]
         .map((id) => childIdToIdx[id])
         .sort((a, b) => a - b);
 
     // The slot number (in the latest attempts activity) that we are replacing
-    const slotNum = lastAttempt.activities.map((a) => a.id).indexOf(childId);
+    const slotNum = state.selectedChildren.map((a) => a.id).indexOf(childId);
 
     const rngSeed =
         state.initialVariant.toString() +
         "|" +
         state.id.toString() +
         "|" +
-        state.attempts.length.toString() +
+        state.attemptNumber.toString() +
         "|" +
         parentAttempt.toString();
 
@@ -613,8 +580,8 @@ export function generateNewSingleDocAttemptForMultiSelect({
         }
     }
 
-    const newActivityStates = [...lastAttempt.activities];
-    const newActivityOptionStates = [...state.latestChildStates];
+    const newActivityStates = [...state.selectedChildren];
+    const newActivityOptionStates = [...state.allChildren];
 
     // Generate a new attempt for the selected child
     const { finalQuestionCounter, state: newChildState } =
@@ -623,30 +590,38 @@ export function generateNewSingleDocAttemptForMultiSelect({
             numActivityVariants,
             initialQuestionCounter,
             questionCounts,
-            parentAttempt: state.attempts.length + 1,
+            parentAttempt: state.attemptNumber + 1,
         });
 
     // Give that child the credit achieved from the child we are replacing
     // as it will be viewed as another attempt for that item.
     const childStatePreserveCredit = { ...newChildState };
     childStatePreserveCredit.creditAchieved =
-        lastAttempt.activities[slotNum].creditAchieved;
+        state.selectedChildren[slotNum].creditAchieved;
+    childStatePreserveCredit.latestCreditAchieved = 0;
 
     newActivityOptionStates[selectedIdx] = childStatePreserveCredit;
     newActivityStates[slotNum] = childStatePreserveCredit;
 
-    const newAttemptState: SelectAttemptState = {
-        activities: newActivityStates,
-        creditAchieved: lastAttempt.creditAchieved, // keep credit achieved the same
-        initialQuestionCounter,
-        // indicate that this select attempt is really just about replacing the child from `slotNum`
-        singleItemReplacementIdx: slotNum,
-    };
+    // calculate the latest credit achieved assuming the score for `slotNum` is zero
+    const latestOtherCreditAchieved = state.selectedChildren
+        .filter((_, i) => i != slotNum)
+        .map((a) => a.latestCreditAchieved);
+    const latestCreditAchieved =
+        latestOtherCreditAchieved.reduce((a, c) => a + c, 0) /
+        state.selectedChildren.length;
 
     const newState: SelectState = {
         ...state,
-        latestChildStates: newActivityOptionStates,
-        attempts: [...state.attempts, newAttemptState],
+        allChildren: newActivityOptionStates,
+        selectedChildren: newActivityStates,
+        creditAchieved: state.creditAchieved, // keep credit achieved the same
+        latestCreditAchieved,
+        previousSelections: [
+            ...state.previousSelections,
+            childStatePreserveCredit.id,
+        ],
+        initialQuestionCounter,
     };
 
     return { finalQuestionCounter, state: newState };
@@ -654,27 +629,30 @@ export function generateNewSingleDocAttemptForMultiSelect({
 
 /**
  * Recurse through the descendants of `activityState`,
- * returning an array of the `creditAchieved` of the latest single document activities,
+ * returning an array of the `creditAchieved` and `latestCreditAchieved` of the latest single document activities,
  * or of select activities that select a single document.
  */
 export function extractSelectItemCredit(
     activityState: SelectState,
-): { id: string; score: number }[] {
+): { id: string; score: number; latestScore: number; docId?: string }[] {
+    if (activityState.attemptNumber === 0) {
+        return [{ id: activityState.id, score: 0, latestScore: 0 }];
+    }
     if (
         activityState.source.numToSelect === 1 &&
-        activityState.latestChildStates.every(
-            (child) => child.type === "singleDoc",
-        )
+        activityState.allChildren.every((child) => child.type === "singleDoc")
     ) {
         // The select acts like a single question, so we just use it's credit achieved
-        return [{ id: activityState.id, score: activityState.creditAchieved }];
-    } else if (activityState.attempts.length === 0) {
-        return [{ id: activityState.id, score: 0 }];
+        return [
+            {
+                id: activityState.id,
+                score: activityState.creditAchieved,
+                latestScore: activityState.latestCreditAchieved,
+                docId: activityState.selectedChildren[0].id,
+            },
+        ];
     } else {
-        const latestAttempt =
-            activityState.attempts[activityState.attempts.length - 1];
-
-        return latestAttempt.activities.flatMap((state) =>
+        return activityState.selectedChildren.flatMap((state) =>
             extractActivityItemCredit(state),
         );
     }
@@ -686,8 +664,8 @@ export function extractSelectItemCredit(
  *
  * If `clearDoenetState` is `true`, then also remove the `doenetState` in single documents.
  *
- * Even if `clearDoenetState` is `false``, still clear `doenetState` on all but the latest attempt
- * and clear it on all `latestChildStates`. In this way, the (potentially large) DoenetML state is saved
+ * Even if `clearDoenetState` is `false``, still clear `doenetState` on all `allChildren`.
+ * In this way, the (potentially large) DoenetML state is saved
  * only where needed to reconstitute the activity state.
  */
 export function pruneSelectStateForSave(
@@ -696,23 +674,15 @@ export function pruneSelectStateForSave(
 ): SelectStateNoSource {
     const { source: _source, ...newState } = { ...activityState };
 
-    const latestChildStates = newState.latestChildStates.map((child) =>
+    const allChildren = newState.allChildren.map((child) =>
         pruneActivityStateForSave(child, true),
     );
 
-    const numAttempts = newState.attempts.length;
+    const selectedChildren = newState.selectedChildren.map((child) =>
+        pruneActivityStateForSave(child, clearDoenetState),
+    );
 
-    const attempts = newState.attempts.map((attempt, i) => ({
-        ...attempt,
-        activities: attempt.activities.map((state) =>
-            pruneActivityStateForSave(
-                state,
-                i !== numAttempts - 1 || clearDoenetState,
-            ),
-        ),
-    }));
-
-    return { ...newState, latestChildStates, attempts };
+    return { ...newState, allChildren, selectedChildren };
 }
 
 /** Reverse the effect of `pruneSelectStateForSave by adding back adding back references to the source */
@@ -720,28 +690,25 @@ export function addSourceToSelectState(
     activityState: SelectStateNoSource,
     source: SelectSource,
 ): SelectState {
-    const latestChildStates = activityState.latestChildStates.map((child) => {
+    const allChildren = activityState.allChildren.map((child) => {
         const idx = source.items.findIndex(
             (src) => src.id === extractSourceId(child.id),
         );
         return addSourceToActivityState(child, source.items[idx]);
     });
 
-    const attempts = activityState.attempts.map((attempt) => ({
-        ...attempt,
-        activities: attempt.activities.map((state) => {
-            const idx = source.items.findIndex(
-                (src) => src.id === extractSourceId(state.id),
-            );
-            return addSourceToActivityState(state, source.items[idx]);
-        }),
-    }));
+    const selectedChildren = activityState.selectedChildren.map((child) => {
+        const idx = source.items.findIndex(
+            (src) => src.id === extractSourceId(child.id),
+        );
+        return addSourceToActivityState(child, source.items[idx]);
+    });
 
     return {
         ...activityState,
         source,
-        latestChildStates,
-        attempts,
+        allChildren,
+        selectedChildren,
     };
 }
 

--- a/src/Activity/sequenceState.ts
+++ b/src/Activity/sequenceState.ts
@@ -49,10 +49,10 @@ export type SequenceState = {
     source: SequenceSource;
     /** Used to seed the random number generate to yield the actual variants of each attempt. */
     initialVariant: number;
-    /** Credit achieved (between 0 and 1) over all attempts of this activity */
+    /** Credit achieved (between 0 and 1) from the latest submission */
     creditAchieved: number;
-    /** Credit achieved from the latest submission */
-    latestCreditAchieved: number;
+    /** The maximum credit achieved over all submissions of this attempt of the activity */
+    maxCreditAchieved: number;
     /** The state of child activities, in their original order */
     allChildren: ActivityState[];
     /** The number of the current attempt */
@@ -111,7 +111,7 @@ export function isSequenceState(obj: unknown): obj is SequenceState {
         isSequenceSource(typedObj.source) &&
         typeof typedObj.initialVariant === "number" &&
         typeof typedObj.creditAchieved === "number" &&
-        typeof typedObj.latestCreditAchieved === "number" &&
+        typeof typedObj.maxCreditAchieved === "number" &&
         Array.isArray(typedObj.allChildren) &&
         typedObj.allChildren.every(isActivityState) &&
         typeof typedObj.attemptNumber === "number" &&
@@ -136,7 +136,7 @@ export function isSequenceStateNoSource(
         (typedObj.parentId === null || typeof typedObj.parentId === "string") &&
         typeof typedObj.initialVariant === "number" &&
         typeof typedObj.creditAchieved === "number" &&
-        typeof typedObj.latestCreditAchieved === "number" &&
+        typeof typedObj.maxCreditAchieved === "number" &&
         Array.isArray(typedObj.allChildren) &&
         typedObj.allChildren.every(isActivityStateNoSource) &&
         typeof typedObj.attemptNumber === "number" &&
@@ -199,7 +199,7 @@ export function initializeSequenceState({
         source,
         initialVariant: variant,
         creditAchieved: 0,
-        latestCreditAchieved: 0,
+        maxCreditAchieved: 0,
         allChildren: childStates,
         attemptNumber: 0,
         orderedChildren: [],
@@ -326,7 +326,7 @@ export function generateNewSequenceAttempt({
     const newState: SequenceState = {
         ...state,
         creditAchieved: 0,
-        latestCreditAchieved: 0,
+        maxCreditAchieved: 0,
         allChildren: unorderedChildStates,
         attemptNumber: state.attemptNumber + 1,
         orderedChildren: orderedChildStates,
@@ -337,14 +337,14 @@ export function generateNewSequenceAttempt({
 
 /**
  * Recurse through the descendants of `activityState`,
- * returning an array of the `creditAchieved` and `latestCreditAchieved` of the latest single document activities,
+ * returning an array of the `creditAchieved` and `maxCreditAchieved` of the latest single document activities,
  * or of select activities that select a single document.
  */
 export function extractSequenceItemCredit(
     activityState: SequenceState,
-): { id: string; score: number; latestScore: number; docId?: string }[] {
+): { id: string; score: number; maxScore: number; docId?: string }[] {
     if (activityState.attemptNumber === 0) {
-        return [{ id: activityState.id, score: 0, latestScore: 0 }];
+        return [{ id: activityState.id, score: 0, maxScore: 0 }];
     } else {
         return activityState.orderedChildren.flatMap((state) =>
             extractActivityItemCredit(state),

--- a/src/Activity/singleDocState.ts
+++ b/src/Activity/singleDocState.ts
@@ -28,7 +28,7 @@ export type SingleDocSource = {
     baseComponentCounts?: Record<string, number | undefined>;
 };
 
-/** The current state of a single doc activity, including all attempts. */
+/** The current state of a single doc activity */
 export type SingleDocState = {
     type: "singleDoc";
     id: string;
@@ -36,10 +36,10 @@ export type SingleDocState = {
     source: SingleDocSource;
     /** Used to seed the random number generate to yield the actual variants of each attempt. */
     initialVariant: number;
-    /** Credit achieved (between 0 and 1) over all attempts of this activity */
+    /** Credit achieved (between 0 and 1) from the latest submission */
     creditAchieved: number;
-    /** Credit achieved from the latest submission */
-    latestCreditAchieved: number;
+    /** The maximum credit achieved over all submissions of this attempt of the activity */
+    maxCreditAchieved: number;
     /** The number of the current attempt */
     attemptNumber: number;
     /** The variant selected for the current attempt */
@@ -91,7 +91,7 @@ export function isSingleDocState(obj: unknown): obj is SingleDocState {
         isSingleDocSource(typedObj.source) &&
         typeof typedObj.initialVariant === "number" &&
         typeof typedObj.creditAchieved === "number" &&
-        typeof typedObj.latestCreditAchieved === "number" &&
+        typeof typedObj.maxCreditAchieved === "number" &&
         typeof typedObj.attemptNumber === "number" &&
         typeof typedObj.currentVariant === "number" &&
         Array.isArray(typedObj.previousVariants) &&
@@ -116,7 +116,7 @@ export function isSingleDocStateNoSource(
         (typedObj.parentId === null || typeof typedObj.parentId === "string") &&
         typeof typedObj.initialVariant === "number" &&
         typeof typedObj.creditAchieved === "number" &&
-        typeof typedObj.latestCreditAchieved === "number" &&
+        typeof typedObj.maxCreditAchieved === "number" &&
         typeof typedObj.attemptNumber === "number" &&
         typeof typedObj.currentVariant === "number" &&
         Array.isArray(typedObj.previousVariants) &&
@@ -160,7 +160,7 @@ export function initializeSingleDocState({
         source,
         initialVariant: variant,
         creditAchieved: 0,
-        latestCreditAchieved: 0,
+        maxCreditAchieved: 0,
         attemptNumber: 0,
         currentVariant: 0,
         previousVariants: [],
@@ -186,7 +186,7 @@ export function initializeSingleDocState({
  * Calculates a value for the next question counter (`finalQuestionCounter`) based on
  * the numbers of questions in the new attempt, as specified by `questionCounts`.
  *
- * If `resetCredit` is true, set the `creditAchieved` of the new attempt to zero.
+ * If `resetCredit` is true, set the `maxCreditAchieved` of the new attempt to zero.
  *
  * The `parentAttempt` counter should be the current attempt number of the parent activity.
  * It is used to ensure that selected variants change with the parent's attempt number.
@@ -247,7 +247,7 @@ export function generateNewSingleDocAttempt({
     const newState: SingleDocState = {
         ...state,
         creditAchieved: 0,
-        latestCreditAchieved: 0,
+        maxCreditAchieved: 0,
         attemptNumber: state.attemptNumber + 1,
         currentVariant: selectedVariant,
         previousVariants: [...state.previousVariants, selectedVariant],
@@ -263,7 +263,7 @@ export function generateNewSingleDocAttempt({
  */
 export function extractSingleDocItemCredit(
     activityState: SingleDocState,
-): { id: string; score: number; latestScore: number; docId: string }[] {
+): { id: string; score: number; maxScore: number; docId: string }[] {
     if (activityState.source.isDescription) {
         return [];
     } else {
@@ -271,7 +271,7 @@ export function extractSingleDocItemCredit(
             {
                 id: activityState.id,
                 score: activityState.creditAchieved,
-                latestScore: activityState.latestCreditAchieved,
+                maxScore: activityState.maxCreditAchieved,
                 docId: activityState.id,
             },
         ];

--- a/src/test/activityState.test.ts
+++ b/src/test/activityState.test.ts
@@ -58,7 +58,7 @@ describe("Activity state tests", () => {
             source: (source.items[0] as SelectSource)
                 .items[0] as SingleDocSource,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -74,7 +74,7 @@ describe("Activity state tests", () => {
             source: (source.items[0] as SelectSource)
                 .items[1] as SingleDocSource,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -90,7 +90,7 @@ describe("Activity state tests", () => {
             parentId: "seq",
             source: source.items[0] as SelectSource,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -103,10 +103,10 @@ describe("Activity state tests", () => {
             type: "singleDoc",
             id: "doc3",
             parentId: "sel2",
-            creditAchieved: 0,
             source: (source.items[1] as SelectSource)
                 .items[0] as SingleDocSource,
-            latestCreditAchieved: 0,
+            creditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -122,7 +122,7 @@ describe("Activity state tests", () => {
             source: (source.items[1] as SelectSource)
                 .items[1] as SingleDocSource,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -138,7 +138,7 @@ describe("Activity state tests", () => {
             source: (source.items[1] as SelectSource)
                 .items[2] as SingleDocSource,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -154,7 +154,7 @@ describe("Activity state tests", () => {
             parentId: "seq",
             source: source.items[1] as SelectSource,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -171,7 +171,7 @@ describe("Activity state tests", () => {
             source: source,
             initialVariant: 1,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             allChildren: [select1State, select2State],
             orderedChildren: [],
@@ -186,7 +186,7 @@ describe("Activity state tests", () => {
             id: "doc4",
             parentId: "sel1",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -200,7 +200,7 @@ describe("Activity state tests", () => {
             id: "doc5",
             parentId: "sel1",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -215,7 +215,7 @@ describe("Activity state tests", () => {
             id: "sel1",
             parentId: "seq",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -229,7 +229,7 @@ describe("Activity state tests", () => {
             id: "doc3",
             parentId: "sel2",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -243,7 +243,7 @@ describe("Activity state tests", () => {
             id: "doc2",
             parentId: "sel2",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -257,7 +257,7 @@ describe("Activity state tests", () => {
             id: "doc1",
             parentId: "sel2",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -272,7 +272,7 @@ describe("Activity state tests", () => {
             id: "sel2",
             parentId: "seq",
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             initialVariant: expect.any(Number),
@@ -288,7 +288,7 @@ describe("Activity state tests", () => {
             parentId: null,
             initialVariant: 1,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             allChildren: [select1StatePruned, select2StatePruned],
             orderedChildren: [],
@@ -345,7 +345,7 @@ describe("Activity state tests", () => {
             source: docSource,
             initialVariant: docVariant,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             doenetState: null,
             initialQuestionCounter: 0,
@@ -361,7 +361,7 @@ describe("Activity state tests", () => {
             source: docSource,
             initialVariant: docVariant,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             doenetState: null,
             initialQuestionCounter: 0,
@@ -377,7 +377,7 @@ describe("Activity state tests", () => {
             source: docSource,
             initialVariant: docVariant,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             doenetState: null,
             initialQuestionCounter: 0,
@@ -393,7 +393,7 @@ describe("Activity state tests", () => {
             source: docSource,
             initialVariant: docVariant,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             doenetState: null,
             initialQuestionCounter: 0,
@@ -409,7 +409,7 @@ describe("Activity state tests", () => {
             source,
             initialVariant: 1,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             attemptNumber: 0,
             initialQuestionCounter: 0,
             selectedChildren: [],

--- a/src/test/activityState.test.ts
+++ b/src/test/activityState.test.ts
@@ -22,16 +22,27 @@ import seq0 from "./testSources/seq0.json";
 import seq2Sel0 from "./testSources/seq2Sel0.json";
 import seqSel0Sel from "./testSources/seqSel0Sel.json";
 
-import { SelectSource, SelectState } from "../Activity/selectState";
-import { SequenceSource, SequenceState } from "../Activity/sequenceState";
+import {
+    SelectSource,
+    SelectState,
+    SelectStateNoSource,
+} from "../Activity/selectState";
+import {
+    SequenceSource,
+    SequenceState,
+    SequenceStateNoSource,
+} from "../Activity/sequenceState";
+import {
+    SingleDocSource,
+    SingleDocState,
+    SingleDocStateNoSource,
+} from "../Activity/singleDocState";
 
 describe("Activity state tests", () => {
     it("prune and add source back to uninitialized state", () => {
         const source = seq2sel as SequenceSource;
 
         const { numActivityVariants } = gatherDocumentStructure(source);
-
-        console.log({ numActivityVariants });
 
         const state = initializeActivityState({
             source,
@@ -40,144 +51,247 @@ describe("Activity state tests", () => {
             numActivityVariants,
         }) as SelectState;
 
-        const expectedState = {
+        const doc1State: SingleDocState = {
+            type: "singleDoc",
+            id: "doc4",
+            parentId: "sel1",
+            source: (source.items[0] as SelectSource)
+                .items[0] as SingleDocSource,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+        const doc2State: SingleDocState = {
+            type: "singleDoc",
+            id: "doc5",
+            parentId: "sel1",
+            source: (source.items[0] as SelectSource)
+                .items[1] as SingleDocSource,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+
+        const select1State: SelectState = {
+            type: "select",
+            id: "sel1",
+            parentId: "seq",
+            source: source.items[0] as SelectSource,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            attemptNumber: 0,
+            previousSelections: [],
+            selectedChildren: [],
+            allChildren: [doc1State, doc2State],
+        };
+        const doc3State: SingleDocState = {
+            type: "singleDoc",
+            id: "doc3",
+            parentId: "sel2",
+            creditAchieved: 0,
+            source: (source.items[1] as SelectSource)
+                .items[0] as SingleDocSource,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+        const doc4State: SingleDocState = {
+            type: "singleDoc",
+            id: "doc2",
+            parentId: "sel2",
+            source: (source.items[1] as SelectSource)
+                .items[1] as SingleDocSource,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+        const doc5State: SingleDocState = {
+            type: "singleDoc",
+            id: "doc1",
+            parentId: "sel2",
+            source: (source.items[1] as SelectSource)
+                .items[2] as SingleDocSource,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+
+        const select2State: SelectState = {
+            type: "select",
+            id: "sel2",
+            parentId: "seq",
+            source: source.items[1] as SelectSource,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            attemptNumber: 0,
+            previousSelections: [],
+            selectedChildren: [],
+            allChildren: [doc3State, doc4State, doc5State],
+        };
+
+        const expectedState: SequenceState = {
             type: "sequence",
             id: "seq",
             parentId: null,
             source: source,
             initialVariant: 1,
             creditAchieved: 0,
-            attempts: [],
-            latestChildStates: [
-                {
-                    type: "select",
-                    id: "sel1",
-                    parentId: "seq",
-                    source: source.items[0],
-                    creditAchieved: 0,
-                    attempts: [],
-                    latestChildStates: [
-                        {
-                            type: "singleDoc",
-                            id: "doc4",
-                            parentId: "sel1",
-                            source: (source.items[0] as SelectSource).items[0],
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                        {
-                            type: "singleDoc",
-                            id: "doc5",
-                            parentId: "sel1",
-                            source: (source.items[0] as SelectSource).items[1],
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                    ],
-                },
-                {
-                    type: "select",
-                    id: "sel2",
-                    parentId: "seq",
-                    source: source.items[1],
-                    creditAchieved: 0,
-                    attempts: [],
-                    latestChildStates: [
-                        {
-                            type: "singleDoc",
-                            id: "doc3",
-                            parentId: "sel2",
-                            source: (source.items[1] as SelectSource).items[0],
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                        {
-                            type: "singleDoc",
-                            id: "doc2",
-                            parentId: "sel2",
-                            source: (source.items[1] as SelectSource).items[1],
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                        {
-                            type: "singleDoc",
-                            id: "doc1",
-                            parentId: "sel2",
-                            source: (source.items[1] as SelectSource).items[2],
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                    ],
-                },
-            ],
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            allChildren: [select1State, select2State],
+            orderedChildren: [],
         };
 
         expect(state).toMatchObject(expectedState);
 
         const prunedState = pruneActivityStateForSave(state);
 
-        const expectedPrunedState = {
+        const doc1StatePruned: SingleDocStateNoSource = {
+            type: "singleDoc",
+            id: "doc4",
+            parentId: "sel1",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+        const doc2StatePruned: SingleDocStateNoSource = {
+            type: "singleDoc",
+            id: "doc5",
+            parentId: "sel1",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+
+        const select1StatePruned: SelectStateNoSource = {
+            type: "select",
+            id: "sel1",
+            parentId: "seq",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            attemptNumber: 0,
+            previousSelections: [],
+            selectedChildren: [],
+            allChildren: [doc1StatePruned, doc2StatePruned],
+        };
+        const doc3StatePruned: SingleDocStateNoSource = {
+            type: "singleDoc",
+            id: "doc3",
+            parentId: "sel2",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+        const doc4StatePruned: SingleDocStateNoSource = {
+            type: "singleDoc",
+            id: "doc2",
+            parentId: "sel2",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+        const doc5StatePruned: SingleDocStateNoSource = {
+            type: "singleDoc",
+            id: "doc1",
+            parentId: "sel2",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            currentVariant: 0,
+            attemptNumber: 0,
+            previousVariants: [],
+            doenetState: null,
+        };
+
+        const select2StatePruned: SelectStateNoSource = {
+            type: "select",
+            id: "sel2",
+            parentId: "seq",
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            initialVariant: expect.any(Number),
+            attemptNumber: 0,
+            previousSelections: [],
+            selectedChildren: [],
+            allChildren: [doc3StatePruned, doc4StatePruned, doc5StatePruned],
+        };
+
+        const expectedPrunedState: SequenceStateNoSource = {
             type: "sequence",
             id: "seq",
             parentId: null,
             initialVariant: 1,
             creditAchieved: 0,
-            attempts: [],
-            latestChildStates: [
-                {
-                    type: "select",
-                    id: "sel1",
-                    parentId: "seq",
-                    creditAchieved: 0,
-                    attempts: [],
-                    latestChildStates: [
-                        {
-                            type: "singleDoc",
-                            id: "doc4",
-                            parentId: "sel1",
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                        {
-                            type: "singleDoc",
-                            id: "doc5",
-                            parentId: "sel1",
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                    ],
-                },
-                {
-                    type: "select",
-                    id: "sel2",
-                    parentId: "seq",
-                    creditAchieved: 0,
-                    attempts: [],
-                    latestChildStates: [
-                        {
-                            type: "singleDoc",
-                            id: "doc3",
-                            parentId: "sel2",
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                        {
-                            type: "singleDoc",
-                            id: "doc2",
-                            parentId: "sel2",
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                        {
-                            type: "singleDoc",
-                            id: "doc1",
-                            parentId: "sel2",
-                            creditAchieved: 0,
-                            attempts: [],
-                        },
-                    ],
-                },
-            ],
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            allChildren: [select1StatePruned, select2StatePruned],
+            orderedChildren: [],
         };
 
         expect(prunedState).not.toMatchObject(expectedState);
@@ -188,12 +302,12 @@ describe("Activity state tests", () => {
         }
 
         expect("source" in prunedState).eq(false);
-        for (const child of prunedState.latestChildStates) {
+        for (const child of prunedState.allChildren) {
             if (child.type !== "select") {
                 throw Error("nope");
             }
             expect("source" in child).eq(false);
-            for (const grandChild of child.latestChildStates) {
+            for (const grandChild of child.allChildren) {
                 expect("source" in grandChild).eq(false);
             }
         }
@@ -211,7 +325,7 @@ describe("Activity state tests", () => {
         // initializeActivityState breaks up its children into slices that have just 1 one variant
 
         const source = selMult1doc as SelectSource;
-        const docSource = source.items[0];
+        const docSource = source.items[0] as SingleDocSource;
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
@@ -222,58 +336,90 @@ describe("Activity state tests", () => {
             numActivityVariants,
         }) as SelectState;
 
-        const docVariant = state.latestChildStates[0].initialVariant;
+        const docVariant = state.allChildren[0].initialVariant;
 
-        const expectedState = {
+        const expectedChild1: SingleDocState = {
+            type: "singleDoc",
+            id: "doc4|1",
+            parentId: "sel",
+            source: docSource,
+            initialVariant: docVariant,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            doenetState: null,
+            initialQuestionCounter: 0,
+            currentVariant: 0,
+            previousVariants: [],
+            restrictToVariantSlice: { idx: 1, numSlices: 4 },
+        };
+
+        const expectedChild2: SingleDocState = {
+            type: "singleDoc",
+            id: "doc4|2",
+            parentId: "sel",
+            source: docSource,
+            initialVariant: docVariant,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            doenetState: null,
+            initialQuestionCounter: 0,
+            currentVariant: 0,
+            previousVariants: [],
+            restrictToVariantSlice: { idx: 2, numSlices: 4 },
+        };
+
+        const expectedChild3: SingleDocState = {
+            type: "singleDoc",
+            id: "doc4|3",
+            parentId: "sel",
+            source: docSource,
+            initialVariant: docVariant,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            doenetState: null,
+            initialQuestionCounter: 0,
+            currentVariant: 0,
+            previousVariants: [],
+            restrictToVariantSlice: { idx: 3, numSlices: 4 },
+        };
+
+        const expectedChild4: SingleDocState = {
+            type: "singleDoc",
+            id: "doc4|4",
+            parentId: "sel",
+            source: docSource,
+            initialVariant: docVariant,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            doenetState: null,
+            initialQuestionCounter: 0,
+            currentVariant: 0,
+            previousVariants: [],
+            restrictToVariantSlice: { idx: 4, numSlices: 4 },
+        };
+
+        const expectedState: SelectState = {
             type: "select",
             id: "sel",
             parentId: null,
             source,
             initialVariant: 1,
             creditAchieved: 0,
-            latestChildStates: [
-                {
-                    type: "singleDoc",
-                    id: "doc4|1",
-                    parentId: "sel",
-                    source: docSource,
-                    initialVariant: docVariant,
-                    creditAchieved: 0,
-                    attempts: [],
-                    restrictToVariantSlice: { idx: 1, numSlices: 4 },
-                },
-                {
-                    type: "singleDoc",
-                    id: "doc4|2",
-                    parentId: "sel",
-                    source: docSource,
-                    initialVariant: docVariant,
-                    creditAchieved: 0,
-                    attempts: [],
-                    restrictToVariantSlice: { idx: 2, numSlices: 4 },
-                },
-                {
-                    type: "singleDoc",
-                    id: "doc4|3",
-                    parentId: "sel",
-                    source: docSource,
-                    initialVariant: docVariant,
-                    creditAchieved: 0,
-                    attempts: [],
-                    restrictToVariantSlice: { idx: 3, numSlices: 4 },
-                },
-                {
-                    type: "singleDoc",
-                    id: "doc4|4",
-                    parentId: "sel",
-                    source: docSource,
-                    initialVariant: docVariant,
-                    creditAchieved: 0,
-                    attempts: [],
-                    restrictToVariantSlice: { idx: 4, numSlices: 4 },
-                },
+            latestCreditAchieved: 0,
+            attemptNumber: 0,
+            initialQuestionCounter: 0,
+            selectedChildren: [],
+            previousSelections: [],
+            allChildren: [
+                expectedChild1,
+                expectedChild2,
+                expectedChild3,
+                expectedChild4,
             ],
-            attempts: [],
             restrictToVariantSlice: undefined,
         };
 
@@ -352,16 +498,10 @@ describe("Activity state tests", () => {
         }) as SequenceState;
 
         expect(
-            calcNumVariantsFromState(
-                state.latestChildStates[0],
-                numActivityVariants,
-            ),
+            calcNumVariantsFromState(state.allChildren[0], numActivityVariants),
         ).eq(numVarSel1);
         expect(
-            calcNumVariantsFromState(
-                state.latestChildStates[1],
-                numActivityVariants,
-            ),
+            calcNumVariantsFromState(state.allChildren[1], numActivityVariants),
         ).eq(numVarSel2);
         expect(calcNumVariantsFromState(state, numActivityVariants)).eq(
             numVarSeq,
@@ -386,7 +526,7 @@ describe("Activity state tests", () => {
         for (let i = 0; i < numVarSel1; i++) {
             expect(
                 calcNumVariantsFromState(
-                    state2.latestChildStates[i],
+                    state2.allChildren[i],
                     numActivityVariants,
                 ),
             ).eq(1);
@@ -409,7 +549,7 @@ describe("Activity state tests", () => {
         for (let i = 0; i < numActivityVariants.doc4; i++) {
             expect(
                 calcNumVariantsFromState(
-                    state3.latestChildStates[i],
+                    state3.allChildren[i],
                     numActivityVariants,
                 ),
             ).eq(1);
@@ -438,17 +578,15 @@ describe("Activity state tests", () => {
 
         const state = newState as SequenceState;
 
-        const firstSelectState = state.latestChildStates[0] as SelectState;
-        const secondSelectState = state.latestChildStates[1] as SelectState;
+        const firstSelectState = state.allChildren[0] as SelectState;
+        const secondSelectState = state.allChildren[1] as SelectState;
 
-        const docFromFirstSelect =
-            firstSelectState.attempts[0].activities[0].id;
+        const docFromFirstSelect = firstSelectState.selectedChildren[0].id;
         expect(["doc4", "doc5"].includes(docFromFirstSelect)).eq(true);
-        const docFromSecondSelect =
-            secondSelectState.attempts[0].activities[0].id;
+        const docFromSecondSelect = secondSelectState.selectedChildren[0].id;
         expect(["doc3", "doc2", "doc1"].includes(docFromSecondSelect)).eq(true);
 
-        if (state.attempts[0].activities[0].id === firstSelectState.id) {
+        if (state.orderedChildren[0].id === firstSelectState.id) {
             expect(getItemSequence(state)).eqls([
                 docFromFirstSelect,
                 docFromSecondSelect,
@@ -552,10 +690,9 @@ describe("Activity state tests", () => {
 
         const state = newState as SequenceState;
 
-        const secondSelectState = state.latestChildStates[1] as SelectState;
+        const secondSelectState = state.allChildren[1] as SelectState;
 
-        const docFromSecondSelect =
-            secondSelectState.attempts[0].activities[0].id;
+        const docFromSecondSelect = secondSelectState.selectedChildren[0].id;
         expect(["doc3", "doc2", "doc1"].includes(docFromSecondSelect)).eq(true);
 
         expect(getItemSequence(state)).eqls([docFromSecondSelect]);

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -46,7 +46,7 @@ describe("Activity reducer tests", () => {
             doenetState: null,
             initialVariant: 5,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
+            maxCreditAchieved: 0,
             initialQuestionCounter: 0,
             currentVariant: 0,
             previousVariants: [],
@@ -104,10 +104,10 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).eqls([
             {
                 subject: "SPLICE.reportScoreByItem",
+                maxScore: 0,
                 score: 0,
-                latestScore: 0,
                 scoreByItem: [
-                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
                 ],
                 activityId: "newId",
             },
@@ -131,8 +131,8 @@ describe("Activity reducer tests", () => {
         }) as SingleDocState;
 
         // artificially set credit on state0
-        state0.creditAchieved = 0.9;
-        state0.latestCreditAchieved = 0.8;
+        state0.maxCreditAchieved = 0.9;
+        state0.creditAchieved = 0.8;
 
         let state = activityStateReducer(state0, {
             type: "generateNewActivityAttempt",
@@ -150,8 +150,8 @@ describe("Activity reducer tests", () => {
         let expectState: SingleDocState = {
             ...state0,
             initialQuestionCounter: 9,
+            maxCreditAchieved: 0,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
             attemptNumber: 1,
             currentVariant: previousVariants[0],
             previousVariants,
@@ -174,10 +174,10 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).eqls([
             {
                 subject: "SPLICE.reportScoreByItem",
+                maxScore: 0,
                 score: 0,
-                latestScore: 0,
                 scoreByItem: [
-                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
                 ],
                 activityId: "newId",
             },
@@ -198,8 +198,8 @@ describe("Activity reducer tests", () => {
         expectState = {
             ...state0,
             initialQuestionCounter: 6,
+            maxCreditAchieved: 0,
             creditAchieved: 0,
-            latestCreditAchieved: 0,
             attemptNumber: 2,
             currentVariant: previousVariants[1],
             previousVariants,
@@ -210,10 +210,10 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
+                maxScore: 0,
                 score: 0,
-                latestScore: 0,
                 scoreByItem: [
-                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -262,8 +262,8 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
+        expect(state.maxCreditAchieved).eq(0.2);
         expect(state.creditAchieved).eq(0.2);
-        expect(state.latestCreditAchieved).eq(0.2);
         expect(state.doenetState).eq("DoenetML state 1");
 
         expect(spy).toHaveBeenCalledTimes(1);
@@ -271,10 +271,15 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
+                maxScore: 0.2,
                 score: 0.2,
-                latestScore: 0.2,
                 scoreByItem: [
-                    { id: "doc5", score: 0.2, latestScore: 0.2, docId: "doc5" },
+                    {
+                        id: "doc5",
+                        maxScore: 0.2,
+                        score: 0.2,
+                        docId: "doc5",
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -297,8 +302,8 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
-        expect(state.creditAchieved).eq(0.2);
-        expect(state.latestCreditAchieved).eq(0.1);
+        expect(state.maxCreditAchieved).eq(0.2);
+        expect(state.creditAchieved).eq(0.1);
         expect(state.doenetState).eq("DoenetML state 2");
 
         expect(spy).toHaveBeenCalledTimes(2);
@@ -306,10 +311,15 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
-                score: 0.2,
-                latestScore: 0.1,
+                maxScore: 0.2,
+                score: 0.1,
                 scoreByItem: [
-                    { id: "doc5", score: 0.2, latestScore: 0.1, docId: "doc5" },
+                    {
+                        id: "doc5",
+                        maxScore: 0.2,
+                        score: 0.1,
+                        docId: "doc5",
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -332,8 +342,8 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
+        expect(state.maxCreditAchieved).eq(0.3);
         expect(state.creditAchieved).eq(0.3);
-        expect(state.latestCreditAchieved).eq(0.3);
         expect(state.doenetState).eq("DoenetML state 3");
 
         expect(spy).toHaveBeenCalledTimes(3);
@@ -341,10 +351,15 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
+                maxScore: 0.3,
                 score: 0.3,
-                latestScore: 0.3,
                 scoreByItem: [
-                    { id: "doc5", score: 0.3, latestScore: 0.3, docId: "doc5" },
+                    {
+                        id: "doc5",
+                        maxScore: 0.3,
+                        score: 0.3,
+                        docId: "doc5",
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -367,8 +382,8 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
+        expect(state.maxCreditAchieved).eq(0.0);
         expect(state.creditAchieved).eq(0.0);
-        expect(state.latestCreditAchieved).eq(0.0);
         expect(state.doenetState).eq(null);
 
         expect(spy).toHaveBeenCalledTimes(4);
@@ -376,10 +391,10 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
+                maxScore: 0,
                 score: 0,
-                latestScore: 0,
                 scoreByItem: [
-                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -402,8 +417,8 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
+        expect(state.maxCreditAchieved).eq(0.1);
         expect(state.creditAchieved).eq(0.1);
-        expect(state.latestCreditAchieved).eq(0.1);
         expect(state.doenetState).eq("DoenetML state 4");
 
         expect(spy).toHaveBeenCalledTimes(5);
@@ -411,10 +426,15 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
+                maxScore: 0.1,
                 score: 0.1,
-                latestScore: 0.1,
                 scoreByItem: [
-                    { id: "doc5", score: 0.1, latestScore: 0.1, docId: "doc5" },
+                    {
+                        id: "doc5",
+                        maxScore: 0.1,
+                        score: 0.1,
+                        docId: "doc5",
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -437,8 +457,8 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
+        expect(state.maxCreditAchieved).eq(0.5);
         expect(state.creditAchieved).eq(0.5);
-        expect(state.latestCreditAchieved).eq(0.5);
         expect(state.doenetState).eq("DoenetML state 5");
 
         expect(spy).toHaveBeenCalledTimes(6);
@@ -446,10 +466,15 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
+                maxScore: 0.5,
                 score: 0.5,
-                latestScore: 0.5,
                 scoreByItem: [
-                    { id: "doc5", score: 0.5, latestScore: 0.5, docId: "doc5" },
+                    {
+                        id: "doc5",
+                        maxScore: 0.5,
+                        score: 0.5,
+                        docId: "doc5",
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -482,13 +507,13 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
-        const credit = state.creditAchieved;
-        expect(credit).closeTo(
+        const maxCreditAchieved = state.maxCreditAchieved;
+        expect(maxCreditAchieved).closeTo(
             docCredits.reduce((a, c) => a + c, 0) / 3,
             1e-12,
         );
-        const latestCredit = state.latestCreditAchieved;
-        expect(latestCredit).closeTo(
+        const creditAchieved = state.creditAchieved;
+        expect(creditAchieved).closeTo(
             docLatestCredits.reduce((a, c) => a + c, 0) / 3,
             1e-12,
         );
@@ -501,8 +526,8 @@ describe("Activity reducer tests", () => {
                 throw Error("Shouldn't happen");
             }
             expect(docState.id).eq(docIds[i]);
-            expect(docState.creditAchieved).eq(docCredits[i]);
-            expect(docState.latestCreditAchieved).eq(docLatestCredits[i]);
+            expect(docState.maxCreditAchieved).eq(docCredits[i]);
+            expect(docState.creditAchieved).eq(docLatestCredits[i]);
             expect(docState.attemptNumber).eq(docAttemptNumbers[i]);
             expect(docState.doenetState).eq(docStates[i]);
         }
@@ -510,25 +535,25 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
-                score: credit,
-                latestScore: latestCredit,
+                maxScore: maxCreditAchieved,
+                score: creditAchieved,
                 scoreByItem: [
                     {
                         id: docIds[0],
-                        score: docCredits[0],
-                        latestScore: docLatestCredits[0],
+                        maxScore: docCredits[0],
+                        score: docLatestCredits[0],
                         docId: docIds[0],
                     },
                     {
                         id: docIds[1],
-                        score: docCredits[1],
-                        latestScore: docLatestCredits[1],
+                        maxScore: docCredits[1],
+                        score: docLatestCredits[1],
                         docId: docIds[1],
                     },
                     {
                         id: docIds[2],
-                        score: docCredits[2],
-                        latestScore: docLatestCredits[2],
+                        maxScore: docCredits[2],
+                        score: docLatestCredits[2],
                         docId: docIds[2],
                     },
                 ],
@@ -977,13 +1002,13 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
-        const credit = state.creditAchieved;
-        expect(credit).closeTo(
+        const maxCreditAchieved = state.maxCreditAchieved;
+        expect(maxCreditAchieved).closeTo(
             selCredits.reduce((a, c) => a + c, 0) / 2,
             1e-12,
         );
-        const latestCredit = state.latestCreditAchieved;
-        expect(latestCredit).closeTo(
+        const creditAchieved = state.creditAchieved;
+        expect(creditAchieved).closeTo(
             selLatestCredits.reduce((a, c) => a + c, 0) / 2,
             1e-12,
         );
@@ -996,8 +1021,8 @@ describe("Activity reducer tests", () => {
                 throw Error("Shouldn't happen");
             }
             expect(selectState.id).eq(selIds[i]);
-            expect(selectState.creditAchieved).eq(selCredits[i]);
-            expect(selectState.latestCreditAchieved).eq(selLatestCredits[i]);
+            expect(selectState.maxCreditAchieved).eq(selCredits[i]);
+            expect(selectState.creditAchieved).eq(selLatestCredits[i]);
             expect(selectState.attemptNumber).eq(selAttemptNumbers[i]);
 
             const docState = selectState.selectedChildren[0];
@@ -1005,8 +1030,8 @@ describe("Activity reducer tests", () => {
                 throw Error("Shouldn't happen");
             }
             expect(docState.id).eq(docIds[i]);
-            expect(docState.creditAchieved).eq(docCredits[i]);
-            expect(docState.latestCreditAchieved).eq(docLatestCredits[i]);
+            expect(docState.maxCreditAchieved).eq(docCredits[i]);
+            expect(docState.creditAchieved).eq(docLatestCredits[i]);
             expect(docState.attemptNumber).eq(docAttemptNumbers[docIds[i]]);
             expect(docState.doenetState).eq(docStates[i]);
         }
@@ -1014,19 +1039,19 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
-                score: credit,
-                latestScore: latestCredit,
+                maxScore: maxCreditAchieved,
+                score: creditAchieved,
                 scoreByItem: [
                     {
                         id: selIds[0],
-                        score: selCredits[0],
-                        latestScore: selLatestCredits[0],
+                        maxScore: selCredits[0],
+                        score: selLatestCredits[0],
                         docId: docIds[0],
                     },
                     {
                         id: selIds[1],
-                        score: selCredits[1],
-                        latestScore: selLatestCredits[1],
+                        maxScore: selCredits[1],
+                        score: selLatestCredits[1],
                         docId: docIds[1],
                     },
                 ],
@@ -1582,13 +1607,13 @@ describe("Activity reducer tests", () => {
             throw Error("Shouldn't happen");
         }
 
-        const credit = state.creditAchieved;
-        expect(credit).closeTo(
+        const maxCreditAchieved = state.maxCreditAchieved;
+        expect(maxCreditAchieved).closeTo(
             docCredits.reduce((a, c) => a + c, 0) / 2,
             1e-12,
         );
-        const latestCredit = state.latestCreditAchieved;
-        expect(latestCredit).closeTo(
+        const creditAchieved = state.creditAchieved;
+        expect(creditAchieved).closeTo(
             docLatestCredits.reduce((a, c) => a + c, 0) / 2,
             1e-12,
         );
@@ -1601,8 +1626,8 @@ describe("Activity reducer tests", () => {
                 throw Error("Shouldn't happen");
             }
             expect(docState.id).eq(docIds[i]);
-            expect(docState.creditAchieved).eq(docCredits[i]);
-            expect(docState.latestCreditAchieved).eq(docLatestCredits[i]);
+            expect(docState.maxCreditAchieved).eq(docCredits[i]);
+            expect(docState.creditAchieved).eq(docLatestCredits[i]);
             expect(docState.attemptNumber).eq(docAttemptNumbers[docIds[i]]);
             expect(docState.doenetState).eq(docStates[i]);
         }
@@ -1610,19 +1635,19 @@ describe("Activity reducer tests", () => {
         expect(spy.mock.lastCall).toMatchObject([
             {
                 subject: "SPLICE.reportScoreAndState",
-                score: credit,
-                latestScore: latestCredit,
+                maxScore: maxCreditAchieved,
+                score: creditAchieved,
                 scoreByItem: [
                     {
                         id: docIds[0],
-                        score: docCredits[0],
-                        latestScore: docLatestCredits[0],
+                        maxScore: docCredits[0],
+                        score: docLatestCredits[0],
                         docId: docIds[0],
                     },
                     {
                         id: docIds[1],
-                        score: docCredits[1],
-                        latestScore: docLatestCredits[1],
+                        maxScore: docCredits[1],
+                        score: docLatestCredits[1],
                         docId: docIds[1],
                     },
                 ],

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -1,0 +1,1880 @@
+import { afterEach, describe, expect, it, MockInstance, vi } from "vitest";
+import { SequenceSource } from "../Activity/sequenceState";
+import {
+    ActivityState,
+    gatherDocumentStructure,
+    initializeActivityState,
+    pruneActivityStateForSave,
+} from "../Activity/activityState";
+import { activityStateReducer } from "../Activity/activityStateReducer";
+import seq2sel from "./testSources/seq2sel.json";
+import doc from "./testSources/doc.json";
+import seqShuf from "./testSources/seqShuf.json";
+import selMult2docs from "./testSources/selMult2docs.json";
+import { SingleDocSource, SingleDocState } from "../Activity/singleDocState";
+import { SelectSource, SelectState } from "../Activity/selectState";
+
+describe("Activity reducer tests", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("initialize", () => {
+        const source0 = seq2sel as SequenceSource;
+        const state0 = initializeActivityState({
+            source: source0,
+            variant: 1,
+            parentId: "abc",
+            numActivityVariants: {},
+        });
+
+        const source = doc as SingleDocSource;
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const newState = activityStateReducer(state0, {
+            type: "initialize",
+            source,
+            variantIndex: 5,
+            numActivityVariants,
+        });
+
+        const expectedState: SingleDocState = {
+            type: "singleDoc",
+            id: source.id,
+            parentId: null,
+            source,
+            doenetState: null,
+            initialVariant: 5,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            initialQuestionCounter: 0,
+            currentVariant: 0,
+            previousVariants: [],
+            attemptNumber: 0,
+            restrictToVariantSlice: undefined,
+        };
+
+        expect(newState).eqls(expectedState);
+    });
+
+    it("set", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source0 = seq2sel as SequenceSource;
+        const state0 = initializeActivityState({
+            source: source0,
+            variant: 1,
+            parentId: "abc",
+            numActivityVariants: {},
+        });
+
+        const source = doc as SingleDocSource;
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let newState = activityStateReducer(state0, {
+            type: "set",
+            state,
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        expect(newState).eqls(state);
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        newState = activityStateReducer(state0, {
+            type: "set",
+            state,
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        expect(newState).eqls(state);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        expect(spy.mock.lastCall).eqls([
+            {
+                subject: "SPLICE.reportScoreByItem",
+                score: 0,
+                latestScore: 0,
+                scoreByItem: [
+                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                ],
+                activityId: "newId",
+            },
+        ]);
+    });
+
+    it("generate new activity attempt", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = doc as SingleDocSource;
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        }) as SingleDocState;
+
+        // artificially set credit on state0
+        state0.creditAchieved = 0.9;
+        state0.latestCreditAchieved = 0.8;
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 9,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        }) as SingleDocState;
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        expect(typeof state.currentVariant).eq("number");
+        const previousVariants = [state.currentVariant];
+
+        let expectState: SingleDocState = {
+            ...state0,
+            initialQuestionCounter: 9,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            attemptNumber: 1,
+            currentVariant: previousVariants[0],
+            previousVariants,
+        };
+
+        expect(state).eqls(expectState);
+
+        state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 9,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        }) as SingleDocState;
+        expect(state).eqls(expectState);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        expect(spy.mock.lastCall).eqls([
+            {
+                subject: "SPLICE.reportScoreByItem",
+                score: 0,
+                latestScore: 0,
+                scoreByItem: [
+                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                ],
+                activityId: "newId",
+            },
+        ]);
+
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 6,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        }) as SingleDocState;
+
+        expect(typeof state.currentVariant).eq("number");
+        previousVariants.push(state.currentVariant);
+
+        expectState = {
+            ...state0,
+            initialQuestionCounter: 6,
+            creditAchieved: 0,
+            latestCreditAchieved: 0,
+            attemptNumber: 2,
+            currentVariant: previousVariants[1],
+            previousVariants,
+        };
+
+        expect(spy).toHaveBeenCalledTimes(2);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0,
+                latestScore: 0,
+                scoreByItem: [
+                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+    });
+
+    it("update single state, single document", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = doc as SingleDocSource;
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        // Get score of 0.2
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: "doc5",
+            doenetState: "DoenetML state 1",
+            creditAchieved: 0.2,
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "singleDoc") {
+            throw Error("Shouldn't happen");
+        }
+
+        expect(state.creditAchieved).eq(0.2);
+        expect(state.latestCreditAchieved).eq(0.2);
+        expect(state.doenetState).eq("DoenetML state 1");
+
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0.2,
+                latestScore: 0.2,
+                scoreByItem: [
+                    { id: "doc5", score: 0.2, latestScore: 0.2, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+
+        // decrease score
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: "doc5",
+            doenetState: "DoenetML state 2",
+            creditAchieved: 0.1,
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "singleDoc") {
+            throw Error("Shouldn't happen");
+        }
+
+        expect(state.creditAchieved).eq(0.2);
+        expect(state.latestCreditAchieved).eq(0.1);
+        expect(state.doenetState).eq("DoenetML state 2");
+
+        expect(spy).toHaveBeenCalledTimes(2);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0.2,
+                latestScore: 0.1,
+                scoreByItem: [
+                    { id: "doc5", score: 0.2, latestScore: 0.1, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+
+        // increase score
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: "doc5",
+            doenetState: "DoenetML state 3",
+            creditAchieved: 0.3,
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "singleDoc") {
+            throw Error("Shouldn't happen");
+        }
+
+        expect(state.creditAchieved).eq(0.3);
+        expect(state.latestCreditAchieved).eq(0.3);
+        expect(state.doenetState).eq("DoenetML state 3");
+
+        expect(spy).toHaveBeenCalledTimes(3);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0.3,
+                latestScore: 0.3,
+                scoreByItem: [
+                    { id: "doc5", score: 0.3, latestScore: 0.3, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+
+        // generate new attempt
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "singleDoc") {
+            throw Error("Shouldn't happen");
+        }
+
+        expect(state.creditAchieved).eq(0.0);
+        expect(state.latestCreditAchieved).eq(0.0);
+        expect(state.doenetState).eq(null);
+
+        expect(spy).toHaveBeenCalledTimes(4);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0,
+                latestScore: 0,
+                scoreByItem: [
+                    { id: "doc5", score: 0, latestScore: 0, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+
+        // start attempt with low score
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: "doc5",
+            doenetState: "DoenetML state 4",
+            creditAchieved: 0.1,
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "singleDoc") {
+            throw Error("Shouldn't happen");
+        }
+
+        expect(state.creditAchieved).eq(0.1);
+        expect(state.latestCreditAchieved).eq(0.1);
+        expect(state.doenetState).eq("DoenetML state 4");
+
+        expect(spy).toHaveBeenCalledTimes(5);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0.1,
+                latestScore: 0.1,
+                scoreByItem: [
+                    { id: "doc5", score: 0.1, latestScore: 0.1, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+
+        // increase score
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: "doc5",
+            doenetState: "DoenetML state 5",
+            creditAchieved: 0.5,
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "singleDoc") {
+            throw Error("Shouldn't happen");
+        }
+
+        expect(state.creditAchieved).eq(0.5);
+        expect(state.latestCreditAchieved).eq(0.5);
+        expect(state.doenetState).eq("DoenetML state 5");
+
+        expect(spy).toHaveBeenCalledTimes(6);
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: 0.5,
+                latestScore: 0.5,
+                scoreByItem: [
+                    { id: "doc5", score: 0.5, latestScore: 0.5, docId: "doc5" },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+    });
+
+    function testStateSeq3Docs({
+        state,
+        docCredits,
+        docLatestCredits,
+        docAttemptNumbers,
+        docStates,
+        docIds,
+        attemptNumber,
+        spy,
+    }: {
+        state: ActivityState;
+        docCredits: number[];
+        docLatestCredits: number[];
+        docAttemptNumbers: number[];
+        docStates: (string | null)[];
+        docIds: string[];
+        attemptNumber: number;
+        spy: MockInstance;
+    }) {
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        const credit = state.creditAchieved;
+        expect(credit).closeTo(
+            docCredits.reduce((a, c) => a + c, 0) / 3,
+            1e-12,
+        );
+        const latestCredit = state.latestCreditAchieved;
+        expect(latestCredit).closeTo(
+            docLatestCredits.reduce((a, c) => a + c, 0) / 3,
+            1e-12,
+        );
+
+        expect(state.attemptNumber).eq(attemptNumber);
+
+        for (let i = 0; i < 2; i++) {
+            const docState = state.orderedChildren[i];
+            if (docState.type !== "singleDoc") {
+                throw Error("Shouldn't happen");
+            }
+            expect(docState.id).eq(docIds[i]);
+            expect(docState.creditAchieved).eq(docCredits[i]);
+            expect(docState.latestCreditAchieved).eq(docLatestCredits[i]);
+            expect(docState.attemptNumber).eq(docAttemptNumbers[i]);
+            expect(docState.doenetState).eq(docStates[i]);
+        }
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: credit,
+                latestScore: latestCredit,
+                scoreByItem: [
+                    {
+                        id: docIds[0],
+                        score: docCredits[0],
+                        latestScore: docLatestCredits[0],
+                        docId: docIds[0],
+                    },
+                    {
+                        id: docIds[1],
+                        score: docCredits[1],
+                        latestScore: docLatestCredits[1],
+                        docId: docIds[1],
+                    },
+                    {
+                        id: docIds[2],
+                        score: docCredits[2],
+                        latestScore: docLatestCredits[2],
+                        docId: docIds[2],
+                    },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+    }
+
+    it("update single state, sequence of three documents, activity-wide new attempts", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = seqShuf as SequenceSource;
+
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine ordered documents
+        const docIds = state.orderedChildren.map((c) => c.id);
+        let docCredits = [0, 0, 0];
+        let docLatestCredits = [0, 0, 0];
+        let docAttemptNumbers = [1, 1, 1];
+        let docStates: (string | null)[] = [null, null, null];
+        let attemptNumber = 1;
+
+        // Get score of 0.4 in first doc
+        docStates[0] = "DoenetML state 1.1";
+        docLatestCredits[0] = docCredits[0] = 0.4;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Get score of 0.6 in second doc
+        docStates[1] = "DoenetML state 2.1";
+        docLatestCredits[1] = docCredits[1] = 0.6;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Decrease score of 0.2 in second doc
+        docStates[1] = "DoenetML state 2.2";
+        docLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt of entire activity
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        attemptNumber++;
+        docAttemptNumbers = docAttemptNumbers.map((x) => x + 1);
+        docCredits = [0, 0, 0];
+        docLatestCredits = [0, 0, 0];
+        docStates = [null, null, null];
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.8 on third doc
+        docStates[2] = "DoenetML state 3.1";
+        docLatestCredits[2] = docCredits[2] = 0.8;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[2],
+            doenetState: docStates[2],
+            creditAchieved: docLatestCredits[2],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+    });
+
+    it("update single state, sequence of three documents, new attempts for documents", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = seqShuf as SequenceSource;
+
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine ordered documents
+        const docIds = state.orderedChildren.map((c) => c.id);
+        const docCredits = [0, 0, 0];
+        const docLatestCredits = [0, 0, 0];
+        const docAttemptNumbers = [1, 1, 1];
+        const docStates: (string | null)[] = [null, null, null];
+        const attemptNumber = 1;
+
+        // Get score of 0.4 in first doc
+        docStates[0] = "DoenetML state 1.1";
+        docLatestCredits[0] = docCredits[0] = 0.4;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Get score of 0.6 in second doc
+        docStates[1] = "DoenetML state 2.1";
+        docLatestCredits[1] = docCredits[1] = 0.6;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Decrease score of 0.2 in second doc
+        docStates[1] = "DoenetML state 2.2";
+        docLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt of first document
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            id: docIds[0],
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        docAttemptNumbers[0]++;
+        docLatestCredits[0] = 0;
+        docStates[0] = null;
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.5 on first doc
+        docStates[0] = "DoenetML state 1.2";
+        docLatestCredits[0] = docCredits[0] = 0.5;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.8 on third doc
+        docStates[2] = "DoenetML state 3.1";
+        docLatestCredits[2] = docCredits[2] = 0.8;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[2],
+            doenetState: docStates[2],
+            creditAchieved: docLatestCredits[2],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0 on second doc
+        docStates[1] = "DoenetML state 2.3";
+        docLatestCredits[1] = 0;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt of second document
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            id: docIds[1],
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        docAttemptNumbers[1]++;
+        docLatestCredits[1] = 0;
+        docStates[1] = null;
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.9 on second doc
+        docStates[1] = "DoenetML state 2.4";
+        docLatestCredits[1] = docCredits[1] = 0.9;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq3Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+    });
+
+    function testStateSeq2Sels({
+        state,
+        selCredits,
+        selLatestCredits,
+        selAttemptNumbers,
+        selIds,
+        docCredits,
+        docLatestCredits,
+        docAttemptNumbers,
+        docStates,
+        docIds,
+        attemptNumber,
+        spy,
+    }: {
+        state: ActivityState;
+        selCredits: number[];
+        selLatestCredits: number[];
+        selAttemptNumbers: number[];
+        selIds: string[];
+        docCredits: number[];
+        docLatestCredits: number[];
+        docAttemptNumbers: Record<string, number>;
+        docStates: (string | null)[];
+        docIds: string[];
+        attemptNumber: number;
+        spy: MockInstance;
+    }) {
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        const credit = state.creditAchieved;
+        expect(credit).closeTo(
+            selCredits.reduce((a, c) => a + c, 0) / 2,
+            1e-12,
+        );
+        const latestCredit = state.latestCreditAchieved;
+        expect(latestCredit).closeTo(
+            selLatestCredits.reduce((a, c) => a + c, 0) / 2,
+            1e-12,
+        );
+
+        expect(state.attemptNumber).eq(attemptNumber);
+
+        for (let i = 0; i < 2; i++) {
+            const selectState = state.orderedChildren[i];
+            if (selectState.type !== "select") {
+                throw Error("Shouldn't happen");
+            }
+            expect(selectState.id).eq(selIds[i]);
+            expect(selectState.creditAchieved).eq(selCredits[i]);
+            expect(selectState.latestCreditAchieved).eq(selLatestCredits[i]);
+            expect(selectState.attemptNumber).eq(selAttemptNumbers[i]);
+
+            const docState = selectState.selectedChildren[0];
+            if (docState.type !== "singleDoc") {
+                throw Error("Shouldn't happen");
+            }
+            expect(docState.id).eq(docIds[i]);
+            expect(docState.creditAchieved).eq(docCredits[i]);
+            expect(docState.latestCreditAchieved).eq(docLatestCredits[i]);
+            expect(docState.attemptNumber).eq(docAttemptNumbers[docIds[i]]);
+            expect(docState.doenetState).eq(docStates[i]);
+        }
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: credit,
+                latestScore: latestCredit,
+                scoreByItem: [
+                    {
+                        id: selIds[0],
+                        score: selCredits[0],
+                        latestScore: selLatestCredits[0],
+                        docId: docIds[0],
+                    },
+                    {
+                        id: selIds[1],
+                        score: selCredits[1],
+                        latestScore: selLatestCredits[1],
+                        docId: docIds[1],
+                    },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+    }
+
+    it("update single state, sequence of two selects, activity-wide new attempts", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = seq2sel as SequenceSource;
+
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine ordered selects and the selected documents
+        let selIds = state.orderedChildren.map((c) => c.id);
+        let docIds = [];
+        for (const a of state.orderedChildren) {
+            if (a.type !== "select") {
+                throw Error("Shouldn't happen");
+            }
+            docIds.push(a.selectedChildren[0].id);
+        }
+
+        let selAttemptNumbers = [1, 1];
+        let selCredits = [0, 0];
+        let selLatestCredits = [0, 0];
+
+        const docAttemptNumbers = { [docIds[0]]: 1, [docIds[1]]: 1 };
+        let docCredits = [0, 0];
+        let docLatestCredits = [0, 0];
+        let docStates: (string | null)[] = [null, null];
+        let attemptNumber = 1;
+
+        // Get score of 0.4 in first doc
+        docStates[0] = "DoenetML state 1.1";
+        docLatestCredits[0] = docCredits[0] = 0.4;
+        selLatestCredits[0] = selCredits[0] = 0.4;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Get score of 0.6 in second doc
+        docStates[1] = "DoenetML state 2.1";
+        docLatestCredits[1] = docCredits[1] = 0.6;
+        selLatestCredits[1] = selCredits[1] = 0.6;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Decrease score of 0.2 in second doc
+        docStates[1] = "DoenetML state 2.2";
+        docLatestCredits[1] = 0.2;
+        selLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt of entire activity
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine ordered selects and the selected documents
+        selIds = state.orderedChildren.map((c) => c.id);
+        docIds = [];
+        for (const a of state.orderedChildren) {
+            if (a.type !== "select") {
+                throw Error("Shouldn't happen");
+            }
+            docIds.push(a.selectedChildren[0].id);
+        }
+        for (let i = 0; i < 2; i++) {
+            docAttemptNumbers[docIds[i]] =
+                (docAttemptNumbers[docIds[i]] ?? 0) + 1;
+        }
+
+        selAttemptNumbers = [2, 2];
+        selCredits = [0, 0];
+        selLatestCredits = [0, 0];
+
+        docCredits = [0, 0];
+        docLatestCredits = [0, 0];
+        docStates = [null, null];
+        attemptNumber++;
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.8 second doc
+        docStates[1] = "DoenetML state 2.3";
+        docCredits[1] = docLatestCredits[1] = 0.8;
+        selCredits[1] = selLatestCredits[1] = 0.8;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+    });
+
+    it("update single state, sequence of two selects, new attempts for selects", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = seq2sel as SequenceSource;
+
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine ordered selects and the selected documents
+        const selIds = state.orderedChildren.map((c) => c.id);
+        const docIds = [];
+        for (const a of state.orderedChildren) {
+            if (a.type !== "select") {
+                throw Error("Shouldn't happen");
+            }
+            docIds.push(a.selectedChildren[0].id);
+        }
+
+        const selAttemptNumbers = [1, 1];
+        const selCredits = [0, 0];
+        const selLatestCredits = [0, 0];
+
+        const docAttemptNumbers = { [docIds[0]]: 1, [docIds[1]]: 1 };
+        const docCredits = [0, 0];
+        const docLatestCredits = [0, 0];
+        const docStates: (string | null)[] = [null, null];
+        const attemptNumber = 1;
+
+        // Get score of 0.4 in first doc
+        docStates[0] = "DoenetML state 1.1";
+        docLatestCredits[0] = docCredits[0] = 0.4;
+        selLatestCredits[0] = selCredits[0] = 0.4;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Get score of 0.6 in second doc
+        docStates[1] = "DoenetML state 2.1";
+        docLatestCredits[1] = docCredits[1] = 0.6;
+        selLatestCredits[1] = selCredits[1] = 0.6;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Decrease score to 0.2 in second doc
+        docStates[1] = "DoenetML state 2.2";
+        docLatestCredits[1] = 0.2;
+        selLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt the second select
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            id: selIds[1],
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        const selectAttempts = [1, 2];
+
+        // determine the identity of the second document
+        docIds[1] = (
+            state.orderedChildren[1] as SelectState
+        ).selectedChildren[0].id;
+        docAttemptNumbers[docIds[1]] = (docAttemptNumbers[docIds[1]] ?? 0) + 1;
+
+        selAttemptNumbers[1]++;
+        selLatestCredits[1] = 0; // don't change selCredit[1], as the credit achieved is remembered
+        docStates[1] = null;
+        docLatestCredits[1] = 0;
+        docCredits[1] = 0; // document doesn't retain the credit achieved
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get new high score of score of 0.8 in second doc
+        docStates[1] = "DoenetML state 2.3";
+        docLatestCredits[1] = docCredits[1] = 0.8;
+        selLatestCredits[1] = selCredits[1] = 0.8;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // decrease score to 0.2 on second doc
+        docStates[1] = "DoenetML state 2.4";
+        docLatestCredits[1] = 0.2;
+        selLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt the first select
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            id: selIds[0],
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "sequence") {
+            throw Error("Shouldn't happen");
+        }
+
+        selectAttempts[0]++;
+
+        // determine the identity of the second document
+        docIds[0] = (
+            state.orderedChildren[0] as SelectState
+        ).selectedChildren[0].id;
+        docAttemptNumbers[docIds[0]] = (docAttemptNumbers[docIds[0]] ?? 0) + 1;
+
+        selAttemptNumbers[0]++;
+        selLatestCredits[0] = 0; // don't change selCredit[0], as the credit achieved is remembered
+        docStates[0] = null;
+        docLatestCredits[0] = 0;
+        docCredits[0] = 0; // document doesn't retain the credit achieved
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.3 on first doc
+        docStates[0] = "DoenetML state 1.2";
+        docLatestCredits[0] = docCredits[0] = 0.3;
+        selLatestCredits[0] = 0.3;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSeq2Sels({
+            state,
+            selCredits,
+            selLatestCredits,
+            selAttemptNumbers,
+            selIds,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+    });
+
+    function testStateSelMult2Docs({
+        state,
+        docCredits,
+        docLatestCredits,
+        docAttemptNumbers,
+        docStates,
+        docIds,
+        attemptNumber,
+        spy,
+    }: {
+        state: ActivityState;
+        docCredits: number[];
+        docLatestCredits: number[];
+        docAttemptNumbers: Record<string, number>;
+        docStates: (string | null)[];
+        docIds: string[];
+        attemptNumber: number;
+        spy: MockInstance;
+    }) {
+        if (state.type !== "select") {
+            throw Error("Shouldn't happen");
+        }
+
+        const credit = state.creditAchieved;
+        expect(credit).closeTo(
+            docCredits.reduce((a, c) => a + c, 0) / 2,
+            1e-12,
+        );
+        const latestCredit = state.latestCreditAchieved;
+        expect(latestCredit).closeTo(
+            docLatestCredits.reduce((a, c) => a + c, 0) / 2,
+            1e-12,
+        );
+
+        expect(state.attemptNumber).eq(attemptNumber);
+
+        for (let i = 0; i < 2; i++) {
+            const docState = state.selectedChildren[i];
+            if (docState.type !== "singleDoc") {
+                throw Error("Shouldn't happen");
+            }
+            expect(docState.id).eq(docIds[i]);
+            expect(docState.creditAchieved).eq(docCredits[i]);
+            expect(docState.latestCreditAchieved).eq(docLatestCredits[i]);
+            expect(docState.attemptNumber).eq(docAttemptNumbers[docIds[i]]);
+            expect(docState.doenetState).eq(docStates[i]);
+        }
+
+        expect(spy.mock.lastCall).toMatchObject([
+            {
+                subject: "SPLICE.reportScoreAndState",
+                score: credit,
+                latestScore: latestCredit,
+                scoreByItem: [
+                    {
+                        id: docIds[0],
+                        score: docCredits[0],
+                        latestScore: docLatestCredits[0],
+                        docId: docIds[0],
+                    },
+                    {
+                        id: docIds[1],
+                        score: docCredits[1],
+                        latestScore: docLatestCredits[1],
+                        docId: docIds[1],
+                    },
+                ],
+                state: {
+                    state: pruneActivityStateForSave(state),
+                },
+                activityId: "newId",
+            },
+        ]);
+    }
+
+    it("update single state, select multiple from 2 docs, new attempts for docs", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = selMult2docs as SelectSource;
+
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state0 = initializeActivityState({
+            source: source,
+            variant: 5,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        let state = activityStateReducer(state0, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: false,
+            baseId: "newId",
+        });
+
+        if (state.type !== "select") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine the selected documents
+        const docIds = state.selectedChildren.map((c) => c.id);
+
+        const docAttemptNumbers = { [docIds[0]]: 1, [docIds[1]]: 1 };
+        const docCredits = [0, 0];
+        const docLatestCredits = [0, 0];
+        const docStates: (string | null)[] = [null, null];
+        const attemptNumber = 1;
+
+        // Get score of 0.4 in first doc
+        docStates[0] = "DoenetML state 1.1";
+        docLatestCredits[0] = docCredits[0] = 0.4;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Get score of 0.6 in second doc
+        docStates[1] = "DoenetML state 2.1";
+        docLatestCredits[1] = docCredits[1] = 0.6;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Decrease score to 0.2 in second doc
+        docStates[1] = "DoenetML state 2.2";
+        docLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt the second document
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            id: docIds[1],
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "select") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine the identity of the second document
+        docIds[1] = state.selectedChildren[1].id;
+        docAttemptNumbers[docIds[1]] = (docAttemptNumbers[docIds[1]] ?? 0) + 1;
+
+        docStates[1] = null;
+        docLatestCredits[1] = 0; // don't change docCredits[1], as the credit achieved is remembered
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get new high score of score of 0.8 in second doc
+        docStates[1] = "DoenetML state 2.3";
+        docLatestCredits[1] = docCredits[1] = 0.8;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // decrease score to 0.2 on second doc
+        docStates[1] = "DoenetML state 2.4";
+        docLatestCredits[1] = 0.2;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[1],
+            doenetState: docStates[1],
+            creditAchieved: docLatestCredits[1],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // Generate new attempt the first document
+        state = activityStateReducer(state, {
+            type: "generateNewActivityAttempt",
+            id: docIds[0],
+            numActivityVariants,
+            initialQuestionCounter: 0,
+            questionCounts: {},
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        if (state.type !== "select") {
+            throw Error("Shouldn't happen");
+        }
+
+        // determine the identity of the second document
+        docIds[0] = state.selectedChildren[0].id;
+        docAttemptNumbers[docIds[0]] = (docAttemptNumbers[docIds[0]] ?? 0) + 1;
+
+        docStates[0] = null;
+        docLatestCredits[0] = 0; // don't change docCredits[0], as the credit achieved is remembered
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+
+        // get score of 0.3 on first doc
+        docStates[0] = "DoenetML state 1.2";
+        docLatestCredits[0] = 0.3;
+        state = activityStateReducer(state, {
+            type: "updateSingleState",
+            id: docIds[0],
+            doenetState: docStates[0],
+            creditAchieved: docLatestCredits[0],
+            allowSaveState: true,
+            baseId: "newId",
+        });
+
+        testStateSelMult2Docs({
+            state,
+            docCredits,
+            docLatestCredits,
+            docAttemptNumbers,
+            docStates,
+            docIds,
+            attemptNumber,
+            spy,
+        });
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,13 @@ export type reportStateMessage = {
     subject: "SPLICE.reportScoreAndState";
     activityId: string;
     score: number;
-    scoreByItem: { id: string; score: number }[];
+    maxScore: number;
+    scoreByItem: {
+        id: string;
+        score: number;
+        maxScore: number;
+        docId?: string;
+    }[];
     state: ExportedActivityState;
 };
 
@@ -93,10 +99,14 @@ export function isReportStateMessage(obj: unknown): obj is reportStateMessage {
         typeObj.subject === "SPLICE.reportScoreAndState" &&
         typeof typeObj.activityId === "string" &&
         typeof typeObj.score === "number" &&
+        typeof typeObj.maxScore === "number" &&
         Array.isArray(typeObj.scoreByItem) &&
         typeObj.scoreByItem.every(
             (item) =>
-                typeof item.id === "string" && typeof item.score === "number",
+                typeof item.id === "string" &&
+                typeof item.score === "number" &&
+                typeof item.maxScore === "number" &&
+                (item.docId === undefined || typeof item.docId === "string"),
         ) &&
         isExportedActivityState(typeObj.state)
     );
@@ -106,7 +116,13 @@ export type reportScoreByItemMessage = {
     subject: "SPLICE.reportScoreByItem";
     activityId: string;
     score: number;
-    scoreByItem: { id: string; score: number }[];
+    maxScore: number;
+    scoreByItem: {
+        id: string;
+        score: number;
+        maxScore: number;
+        docId?: string;
+    }[];
 };
 
 export function isReportScoreByItemMessage(
@@ -122,10 +138,14 @@ export function isReportScoreByItemMessage(
         typeObj.subject === "SPLICE.reportScoreByItem" &&
         typeof typeObj.activityId === "string" &&
         typeof typeObj.score === "number" &&
+        typeof typeObj.maxScore === "number" &&
         Array.isArray(typeObj.scoreByItem) &&
         typeObj.scoreByItem.every(
             (item) =>
-                typeof item.id === "string" && typeof item.score === "number",
+                typeof item.id === "string" &&
+                typeof item.score === "number" &&
+                typeof item.maxScore === "number" &&
+                (item.docId === undefined || typeof item.docId === "string"),
         )
     );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,3 +161,17 @@ export type QuestionCountRecord = Record<string, number>;
  * so each slice contains just a single variant.
  */
 export type RestrictToVariantSlice = { idx: number; numSlices: number };
+
+export function isRestrictToVariantSlice(
+    obj: unknown,
+): obj is RestrictToVariantSlice {
+    const typeObj = obj as RestrictToVariantSlice;
+
+    return (
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        typeObj !== null &&
+        typeof typeObj === "object" &&
+        typeof typeObj.idx === "number" &&
+        typeof typeObj.numSlices === "number"
+    );
+}


### PR DESCRIPTION
This PR simplifies activity state so that it contains information only about the current attempt, rather than retaining the states of all previous attempts. When a new activity is generated, credit achieved is reset to zero.

When a new attempt of a sub-activities is created, the credit achieved of that sub-activity is preserved so that the credit achieved of the overall attempt does not drop.

We now track credit achieved in two ways. The `creditAchieved` field of activities is unchanged and still tracks the maximum credit achieved for the attempt. We introduce a `latestCreditAchieved` field that represents the credit achieved from the latest submission.