### PR TITLE
Add ability to render just one item

### DIFF
--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -23,6 +23,7 @@ export function Activity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
+    renderOnlyItem = null,
 }: {
     flags: DoenetMLFlags;
     baseId: string;
@@ -45,9 +46,13 @@ export function Activity({
     hasRenderedCallback: (id: string) => void;
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
+    renderOnlyItem?: number | null;
 }) {
     switch (state.type) {
         case "singleDoc": {
+            if (renderOnlyItem !== null && renderOnlyItem !== 1) {
+                return null;
+            }
             return (
                 <SingleDocActivity
                     flags={flags}
@@ -92,6 +97,7 @@ export function Activity({
                     hasRenderedCallback={hasRenderedCallback}
                     reportVisibility={reportVisibility}
                     reportVisibilityCallback={reportVisibilityCallback}
+                    renderOnlyItem={renderOnlyItem}
                 />
             );
         }
@@ -116,6 +122,7 @@ export function Activity({
                     hasRenderedCallback={hasRenderedCallback}
                     reportVisibility={reportVisibility}
                     reportVisibilityCallback={reportVisibilityCallback}
+                    renderOnlyItem={renderOnlyItem}
                 />
             );
         }

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -81,7 +81,7 @@ export function SelectActivity({
         selectedIds.push(activity.id);
 
         if (nextRenderOnly !== null) {
-            // if have selected more than one, account for the items of previous selection(s)
+            // if `numToSelect` is larger than one, account for the items of previous selection(s)
             nextRenderOnly -= getNumItems(activity.source);
         }
     }

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import type { DoenetMLFlags } from "../types";
 import { SelectState } from "./selectState";
 import { Activity } from "./Activity";
-import { ActivityState } from "./activityState";
+import { ActivityState, getNumItems } from "./activityState";
 
 export function SelectActivity({
     flags,
@@ -23,6 +23,7 @@ export function SelectActivity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
+    renderOnlyItem = null,
 }: {
     flags: DoenetMLFlags;
     baseId: string;
@@ -45,9 +46,12 @@ export function SelectActivity({
     hasRenderedCallback: (id: string) => void;
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
+    renderOnlyItem?: number | null;
 }) {
     const selectedActivities: ReactElement[] = [];
     const selectedIds: string[] = [];
+
+    let nextRenderOnly = renderOnlyItem;
 
     for (const activity of state.selectedChildren) {
         selectedActivities.push(
@@ -71,9 +75,15 @@ export function SelectActivity({
                 hasRenderedCallback={hasRenderedCallback}
                 reportVisibility={reportVisibility}
                 reportVisibilityCallback={reportVisibilityCallback}
+                renderOnlyItem={nextRenderOnly}
             />,
         );
         selectedIds.push(activity.id);
+
+        if (nextRenderOnly !== null) {
+            // if have selected more than one, account for the items of previous selection(s)
+            nextRenderOnly -= getNumItems(activity.source);
+        }
     }
 
     return (

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -79,7 +79,7 @@ export function SequenceActivity({
         );
 
         if (nextRenderOnly !== null) {
-            // if than one item in sequence, account for the items of previous items(s)
+            // if more than one item in sequence, account for the items of previous items(s)
             nextRenderOnly -= getNumItems(activity.source);
         }
     }

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import type { DoenetMLFlags } from "../types";
 import { Activity } from "./Activity";
 import { SequenceState } from "./sequenceState";
-import { ActivityState } from "./activityState";
+import { ActivityState, getNumItems } from "./activityState";
 
 export function SequenceActivity({
     flags,
@@ -23,6 +23,7 @@ export function SequenceActivity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
+    renderOnlyItem = null,
 }: {
     flags: DoenetMLFlags;
     baseId: string;
@@ -45,8 +46,11 @@ export function SequenceActivity({
     hasRenderedCallback: (id: string) => void;
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
+    renderOnlyItem?: number | null;
 }) {
     const activityList: ReactElement[] = [];
+
+    let nextRenderOnly = renderOnlyItem;
 
     for (const activity of state.orderedChildren) {
         activityList.push(
@@ -70,8 +74,14 @@ export function SequenceActivity({
                 hasRenderedCallback={hasRenderedCallback}
                 reportVisibility={reportVisibility}
                 reportVisibilityCallback={reportVisibilityCallback}
+                renderOnlyItem={nextRenderOnly}
             />,
         );
+
+        if (nextRenderOnly !== null) {
+            // if than one item in sequence, account for the items of previous items(s)
+            nextRenderOnly -= getNumItems(activity.source);
+        }
     }
 
     return (

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -25,12 +25,14 @@ import {
     SelectSource,
     SelectState,
     SelectStateNoSource,
+    getNumItemsInSelect,
 } from "./selectState";
 import {
     addSourceToSequenceState,
     calcNumVariantsSequence,
     extractSequenceItemCredit,
     generateNewSequenceAttempt,
+    getNumItemsInSequence,
     initializeSequenceState,
     isSequenceSource,
     isSequenceState,
@@ -502,6 +504,29 @@ export function calcNumVariantsFromState(
     }
 
     return numVariants;
+}
+
+/**
+ * Return the number of documents that will be rendered by this activity.
+ *
+ * Since it is possible that the number of documents rendered will vary
+ * depending on which option(s) are selected by any select,
+ * this number is an upper bound on the number of documents that could be rendered.
+ */
+export function getNumItems(source: ActivitySource): number {
+    switch (source.type) {
+        case "singleDoc": {
+            return 1;
+        }
+        case "select": {
+            return getNumItemsInSelect(source);
+        }
+        case "sequence": {
+            return getNumItemsInSequence(source);
+        }
+    }
+
+    throw Error("Invalid activity type");
 }
 
 /** Validate the ids in `source` to make sure no id contains a `|` and all ids are unique. */

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -14,6 +14,7 @@ import {
     extractActivityItemCredit,
     extractSourceId,
     generateNewActivityAttempt,
+    getNumItems,
     initializeActivityState,
     isActivitySource,
     isActivityState,
@@ -732,4 +733,24 @@ export function calcNumVariantsSelect(
     );
 
     return Math.floor(numVariantsTot / source.numToSelect);
+}
+
+/**
+ * Return the number of documents that will be rendered by this select.
+ *
+ * Since it is possible that the number of documents rendered will vary depending on which option(s) are selected,
+ * this number is an upper bound on the number of documents that could be rendered.
+ */
+export function getNumItemsInSelect(source: SelectSource): number {
+    const numToSelect = source.numToSelect;
+
+    const numDocumentsForEachItem = source.items.map(getNumItems);
+
+    // Take the maximum number of documents, so number returned is an upper bound
+    const numDocumentsPerItem = numDocumentsForEachItem.reduce(
+        (a, c) => Math.max(a, c),
+        0,
+    );
+
+    return numToSelect * numDocumentsPerItem;
 }

--- a/src/Activity/sequenceState.ts
+++ b/src/Activity/sequenceState.ts
@@ -7,6 +7,7 @@ import {
     extractActivityItemCredit,
     extractSourceId,
     generateNewActivityAttempt,
+    getNumItems,
     initializeActivityState,
     isActivitySource,
     isActivityState,
@@ -434,4 +435,18 @@ export function calcNumVariantsSequence(
     }
 
     return numVariants;
+}
+
+/**
+ * Return the number of documents that will be rendered by this sequence.
+ */
+export function getNumItemsInSequence(source: SequenceSource): number {
+    const numDocumentsForEachItem = source.items.map(getNumItems);
+
+    const totalNumDocuments = numDocumentsForEachItem.reduce(
+        (a, c) => a + c,
+        0,
+    );
+
+    return totalNumDocuments;
 }

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -30,7 +30,7 @@ export function Viewer({
     source,
     flags,
     activityId,
-    userId,
+    userId = null,
     attemptNumber: _attemptNumber = 1,
     variantIndex: initialVariantIndex,
     maxAttemptsAllowed: _maxAttemptsAllowed = Infinity,
@@ -48,11 +48,12 @@ export function Viewer({
     darkMode = "light",
     showAnswerTitles = false,
     showTitle = true,
+    renderOnlyItem = null,
 }: {
     source: ActivitySource;
     flags: DoenetMLFlags;
     activityId: string;
-    userId?: string;
+    userId?: string | null;
     attemptNumber?: number;
     variantIndex: number;
     maxAttemptsAllowed?: number;
@@ -70,6 +71,7 @@ export function Viewer({
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
     showTitle?: boolean;
+    renderOnlyItem?: number | null;
 }) {
     const [errMsg, setErrMsg] = useState<string | null>(null);
 
@@ -527,6 +529,7 @@ export function Viewer({
                 hasRenderedCallback={hasRenderedCallback}
                 reportVisibility={!paginate}
                 reportVisibilityCallback={reportVisibilityCallback}
+                renderOnlyItem={renderOnlyItem}
             />
         </div>
     );

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -32,7 +32,7 @@ export function ActivityViewer({
     source,
     flags: specifiedFlags = {},
     activityId = "a",
-    userId,
+    userId = null,
     attemptNumber = 1,
     requestedVariantIndex,
     maxAttemptsAllowed = Infinity,
@@ -51,11 +51,12 @@ export function ActivityViewer({
     showAnswerTitles = false,
     includeVariantSelector: _includeVariantSelector = false,
     showTitle = true,
+    renderOnlyItem = null,
 }: {
     source: ActivitySource;
     flags?: DoenetMLFlagsSubset;
     activityId?: string;
-    userId?: string;
+    userId?: string | null;
     attemptNumber?: number;
     requestedVariantIndex?: number;
     maxAttemptsAllowed?: number;
@@ -74,6 +75,7 @@ export function ActivityViewer({
     showAnswerTitles?: boolean;
     includeVariantSelector?: boolean;
     showTitle?: boolean;
+    renderOnlyItem?: number | null;
 }) {
     // const [variants, setVariants] = useState({
     //     index: 1,
@@ -148,6 +150,7 @@ export function ActivityViewer({
                 darkMode={darkMode}
                 showAnswerTitles={showAnswerTitles}
                 showTitle={showTitle}
+                renderOnlyItem={renderOnlyItem}
             />
         </ErrorBoundary>
     );

--- a/src/test/activityState.test.ts
+++ b/src/test/activityState.test.ts
@@ -7,6 +7,7 @@ import {
     gatherDocumentStructure,
     generateNewActivityAttempt,
     getItemSequence,
+    getNumItems,
     initializeActivityState,
     pruneActivityStateForSave,
     validateIds,
@@ -21,6 +22,7 @@ import sel0 from "./testSources/sel0.json";
 import seq0 from "./testSources/seq0.json";
 import seq2Sel0 from "./testSources/seq2Sel0.json";
 import seqSel0Sel from "./testSources/seqSel0Sel.json";
+import sel2seq from "./testSources/sel2seq.json";
 
 import {
     SelectSource,
@@ -719,5 +721,19 @@ describe("Activity state tests", () => {
                 parentAttempt: 1,
             }),
         ).toThrowError("larger than the number of available activities");
+    });
+
+    it("return number of documents", () => {
+        expect(getNumItems(seq2sel as SequenceSource)).eq(2);
+
+        // upper bound when ambiguous
+        expect(getNumItems(sel2seq as SelectSource)).eq(3);
+
+        expect(getNumItems(selMult2docs as SelectSource)).eq(2);
+        expect(getNumItems(selMult1doc as SelectSource)).eq(3);
+
+        // handle cases with no items
+        expect(getNumItems(sel0 as SelectSource)).eq(0);
+        expect(getNumItems(seq0 as SequenceSource)).eq(0);
     });
 });


### PR DESCRIPTION
This PR adds a `renderOnlyItem` attribute which, if set, causes just the specified item to be rendered.

Since the number of items rendered by select activities could vary, the enumeration of items for `renderOnlyItem` assumes that each select rendered the maximum number of items.