### PR TITLE
items scores are in original order with shuffled order specified

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -233,8 +233,6 @@ function App() {
         }[]
     >([]);
 
-    console.log(activityState);
-
     useEffect(() => {
         const stateListener = function (e: MessageEvent) {
             if (e.data.activityId !== activityId) {

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -3,8 +3,7 @@ import { useEffect, useState } from "react";
 import { ActivityViewer } from "../src/activity-viewer";
 import activitySource from "./testActivity.json";
 
-// import initialAssignmentState from "./testInitialState.json";
-const initialAssignmentState = null;
+import initialAssignmentState from "./testInitialState.json";
 import {
     ExportedActivityState,
     isActivitySource,
@@ -224,9 +223,17 @@ function App() {
         );
 
     const [_score, setScore] = useState(0);
-    const [scoreByItem, setScoreByItem] = useState<
-        { id: string; score: number; maxScore: number; docId?: string }[]
+    const [itemScores, setItemScores] = useState<
+        {
+            id: string;
+            score: number;
+            maxScore: number;
+            docId?: string;
+            shuffledOrder: number;
+        }[]
     >([]);
+
+    console.log(activityState);
 
     useEffect(() => {
         const stateListener = function (e: MessageEvent) {
@@ -241,10 +248,10 @@ function App() {
             if (isReportStateMessage(msg)) {
                 setActivityState(msg.state);
                 setScore(msg.score);
-                setScoreByItem(msg.scoreByItem);
+                setItemScores(msg.itemScores);
             } else if (isReportScoreByItemMessage(msg)) {
                 setScore(msg.score);
-                setScoreByItem(msg.scoreByItem);
+                setItemScores(msg.itemScores);
             } else if (e.data.subject === "SPLICE.getState") {
                 const haveState = validateStateAndSource(
                     initialAssignmentState,
@@ -313,9 +320,11 @@ function App() {
                 <div>
                     Credit by item, latest attempt:
                     <ol>
-                        {scoreByItem.map((item) => (
-                            <li key={item.id}>{item.score * 100}%</li>
-                        ))}
+                        {[...itemScores]
+                            .sort((a, b) => a.shuffledOrder - b.shuffledOrder)
+                            .map((item) => (
+                                <li key={item.id}>{item.score * 100}%</li>
+                            ))}
                     </ol>
                 </div>
                 <div>

--- a/dev/testInitialState.json
+++ b/dev/testInitialState.json
@@ -3,278 +3,1039 @@
         "type": "sequence",
         "id": "seq",
         "parentId": null,
-        "initialVariant": 445663,
-        "creditAchieved": 0.5,
+        "initialVariant": 210305,
+        "creditAchieved": 0.25,
+        "maxCreditAchieved": 0.25,
         "allChildren": [
             {
                 "type": "select",
                 "id": "sel",
                 "parentId": "seq",
-                "initialVariant": 144857,
-                "creditAchieved": 0,
+                "initialVariant": 674202,
+                "creditAchieved": 0.5,
+                "maxCreditAchieved": 0.5,
                 "allChildren": [
                     {
                         "type": "singleDoc",
-                        "id": "qrf",
+                        "id": "qrf|1",
                         "parentId": "sel",
-                        "initialVariant": 674309,
-                        "creditAchieved": 0,
-                        "attempts": []
+                        "initialVariant": 220521,
+                        "creditAchieved": 1,
+                        "maxCreditAchieved": 1,
+                        "attemptNumber": 1,
+                        "currentVariant": 1,
+                        "previousVariants": [1],
+                        "initialQuestionCounter": 2,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 1,
+                            "numSlices": 10
+                        }
                     },
                     {
                         "type": "singleDoc",
-                        "id": "abc",
+                        "id": "qrf|2",
                         "parentId": "sel",
-                        "initialVariant": 451823,
+                        "initialVariant": 220521,
                         "creditAchieved": 0,
-                        "attempts": [
-                            {
-                                "variant": 6,
-                                "doenetState": null,
-                                "creditAchieved": 0,
-                                "initialQuestionCounter": 1
-                            }
-                        ]
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 2,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|3",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 3,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|4",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 4,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|5",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 1,
+                        "maxCreditAchieved": 1,
+                        "attemptNumber": 1,
+                        "currentVariant": 5,
+                        "previousVariants": [5],
+                        "initialQuestionCounter": 2,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 5,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|6",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 6,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|7",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 7,
+                        "previousVariants": [7],
+                        "initialQuestionCounter": 1,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 7,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|8",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 8,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|9",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 9,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|10",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 10,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|1",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 1,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|2",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 2,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|3",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 3,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|4",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 4,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|5",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 5,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|6",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 6,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|7",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 7,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|8",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 8,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|9",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 9,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|10",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 10,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|11",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 11,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|12",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 12,
+                        "previousVariants": [12],
+                        "initialQuestionCounter": 3,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 12,
+                            "numSlices": 12
+                        }
                     }
                 ],
-                "attempts": [
+                "attemptNumber": 2,
+                "selectedChildren": [
                     {
-                        "activities": [
-                            {
-                                "type": "singleDoc",
-                                "id": "abc",
-                                "parentId": "sel",
-                                "initialVariant": 451823,
-                                "creditAchieved": 0,
-                                "attempts": [
-                                    {
-                                        "variant": 6,
-                                        "doenetState": null,
-                                        "creditAchieved": 0,
-                                        "initialQuestionCounter": 1
-                                    }
-                                ]
-                            }
-                        ],
+                        "type": "singleDoc",
+                        "id": "qrf|5",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 1,
+                        "maxCreditAchieved": 1,
+                        "attemptNumber": 1,
+                        "currentVariant": 5,
+                        "previousVariants": [5],
+                        "initialQuestionCounter": 2,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 5,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|12",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
                         "creditAchieved": 0,
-                        "initialQuestionCounter": 1
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 12,
+                        "previousVariants": [12],
+                        "initialQuestionCounter": 3,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 12,
+                            "numSlices": 12
+                        }
                     }
-                ]
+                ],
+                "previousSelections": ["qrf|7", "qrf|1", "qrf|5", "abc|12"],
+                "initialQuestionCounter": 2
             },
             {
                 "type": "select",
                 "id": "sel2",
                 "parentId": "seq",
-                "initialVariant": 283829,
-                "creditAchieved": 1,
+                "initialVariant": 269772,
+                "creditAchieved": 0,
+                "maxCreditAchieved": 0,
                 "allChildren": [
                     {
                         "type": "singleDoc",
                         "id": "sel2a",
                         "parentId": "sel2",
-                        "initialVariant": 129288,
+                        "initialVariant": 543722,
                         "creditAchieved": 0,
-                        "attempts": []
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null
                     },
                     {
                         "type": "singleDoc",
                         "id": "sel2b",
                         "parentId": "sel2",
-                        "initialVariant": 923531,
+                        "initialVariant": 8813,
                         "creditAchieved": 0,
-                        "attempts": []
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null
                     },
                     {
                         "type": "singleDoc",
                         "id": "sel2c",
                         "parentId": "sel2",
-                        "initialVariant": 422157,
-                        "creditAchieved": 1,
-                        "attempts": [
-                            {
-                                "variant": 2,
-                                "doenetState": null,
-                                "creditAchieved": 1,
-                                "initialQuestionCounter": 3
-                            }
-                        ]
+                        "initialVariant": 305570,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 2,
+                        "currentVariant": 6,
+                        "previousVariants": [3, 6],
+                        "initialQuestionCounter": 1,
+                        "doenetState": null
                     },
                     {
                         "type": "singleDoc",
                         "id": "sel2d",
                         "parentId": "sel2",
-                        "initialVariant": 828100,
+                        "initialVariant": 468285,
                         "creditAchieved": 0,
-                        "attempts": []
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null
                     }
                 ],
-                "attempts": [
+                "attemptNumber": 2,
+                "selectedChildren": [
                     {
-                        "activities": [
-                            {
-                                "type": "singleDoc",
-                                "id": "sel2c",
-                                "parentId": "sel2",
-                                "initialVariant": 422157,
-                                "creditAchieved": 1,
-                                "attempts": [
-                                    {
-                                        "variant": 2,
-                                        "doenetState": null,
-                                        "creditAchieved": 1,
-                                        "initialQuestionCounter": 3
-                                    }
-                                ]
-                            }
-                        ],
-                        "creditAchieved": 1,
-                        "initialQuestionCounter": 3
+                        "type": "singleDoc",
+                        "id": "sel2c",
+                        "parentId": "sel2",
+                        "initialVariant": 305570,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 2,
+                        "currentVariant": 6,
+                        "previousVariants": [3, 6],
+                        "initialQuestionCounter": 1,
+                        "doenetState": null
                     }
-                ]
+                ],
+                "previousSelections": ["sel2c", "sel2c"],
+                "initialQuestionCounter": 1
             }
         ],
-        "attempts": [
+        "attemptNumber": 2,
+        "orderedChildren": [
             {
-                "activities": [
+                "type": "select",
+                "id": "sel2",
+                "parentId": "seq",
+                "initialVariant": 269772,
+                "creditAchieved": 0,
+                "maxCreditAchieved": 0,
+                "allChildren": [
                     {
-                        "type": "select",
-                        "id": "sel",
-                        "parentId": "seq",
-                        "initialVariant": 144857,
+                        "type": "singleDoc",
+                        "id": "sel2a",
+                        "parentId": "sel2",
+                        "initialVariant": 543722,
                         "creditAchieved": 0,
-                        "allChildren": [
-                            {
-                                "type": "singleDoc",
-                                "id": "qrf",
-                                "parentId": "sel",
-                                "initialVariant": 674309,
-                                "creditAchieved": 0,
-                                "attempts": []
-                            },
-                            {
-                                "type": "singleDoc",
-                                "id": "abc",
-                                "parentId": "sel",
-                                "initialVariant": 451823,
-                                "creditAchieved": 0,
-                                "attempts": [
-                                    {
-                                        "variant": 6,
-                                        "doenetState": null,
-                                        "creditAchieved": 0,
-                                        "initialQuestionCounter": 1
-                                    }
-                                ]
-                            }
-                        ],
-                        "attempts": [
-                            {
-                                "activities": [
-                                    {
-                                        "type": "singleDoc",
-                                        "id": "abc",
-                                        "parentId": "sel",
-                                        "initialVariant": 451823,
-                                        "creditAchieved": 0,
-                                        "attempts": [
-                                            {
-                                                "variant": 6,
-                                                "doenetState": null,
-                                                "creditAchieved": 0,
-                                                "initialQuestionCounter": 1
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "creditAchieved": 0,
-                                "initialQuestionCounter": 1
-                            }
-                        ]
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null
                     },
                     {
-                        "type": "select",
-                        "id": "sel2",
-                        "parentId": "seq",
-                        "initialVariant": 283829,
-                        "creditAchieved": 1,
-                        "allChildren": [
-                            {
-                                "type": "singleDoc",
-                                "id": "sel2a",
-                                "parentId": "sel2",
-                                "initialVariant": 129288,
-                                "creditAchieved": 0,
-                                "attempts": []
-                            },
-                            {
-                                "type": "singleDoc",
-                                "id": "sel2b",
-                                "parentId": "sel2",
-                                "initialVariant": 923531,
-                                "creditAchieved": 0,
-                                "attempts": []
-                            },
-                            {
-                                "type": "singleDoc",
-                                "id": "sel2c",
-                                "parentId": "sel2",
-                                "initialVariant": 422157,
-                                "creditAchieved": 1,
-                                "attempts": [
-                                    {
-                                        "variant": 2,
-                                        "doenetState": null,
-                                        "creditAchieved": 1,
-                                        "initialQuestionCounter": 3
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "singleDoc",
-                                "id": "sel2d",
-                                "parentId": "sel2",
-                                "initialVariant": 828100,
-                                "creditAchieved": 0,
-                                "attempts": []
-                            }
-                        ],
-                        "attempts": [
-                            {
-                                "activities": [
-                                    {
-                                        "type": "singleDoc",
-                                        "id": "sel2c",
-                                        "parentId": "sel2",
-                                        "initialVariant": 422157,
-                                        "creditAchieved": 1,
-                                        "attempts": [
-                                            {
-                                                "variant": 2,
-                                                "doenetState": {
-                                                    "cid": "bafkreiap46s2hf7xl2x62gi55atlptcdjakhyrqrdieyz2xex3335ddh6u",
-                                                    "coreInfo": "{\"generatedVariantString\":\"{\\\"index\\\":2,\\\"name\\\":\\\"b\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_document1\\\"},\\\"subvariants\\\":[{\\\"index\\\":2,\\\"name\\\":\\\"b\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_question1\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[2],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence1\\\"}}]}]}\",\"allPossibleVariants\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"rendererTypesInDocument\":[\"section\",\"p\",\"number\",\"text\",\"answer\",\"mathInput\",\"vector\",\"math\"],\"documentToRender\":{\"componentName\":\"/_document1\",\"effectiveName\":\"/_document1\",\"componentType\":\"document\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_document1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_document1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_document1\"}}}}",
-                                                    "coreState": "{\"/__copy_d9bmzOvKly\":{\"targetSourcesName\":null,\"sourcesChildNumber\":null,\"sourceIndex\":null},\"/_selectfromsequence1\":{\"errorMessage\":\"\",\"selectedValues\":[2],\"selectedIndices\":[2]},\"/__mathinput_KXh6glTyP5\":{\"rawRendererValue\":\"2\",\"lastValueForDisplay\":2,\"immediateValue\":2,\"immediateValueChanged\":true,\"dontUpdateRawValueInDefinition\":false,\"valueChanged\":true,\"value\":2},\"/_answer1\":{\"justSubmitted\":true,\"hasBeenCorrect\":true,\"creditAchieved\":1,\"responseHasBeenSubmitted\":true,\"numSubmittedResponses\":1,\"submittedResponses\":{\"0\":2,\"mergeObject\":true},\"submittedResponsesComponentType\":[\"math\"],\"creditAchievedDependenciesAtSubmit\":\"z9Uie+zgrfp7WzGfqlET6q/pCD0=\",\"numSubmissions\":1},\"/_document1\":{\"theme\":\"light\"},\"/__award_XTZPmlFGuS\":{\"awarded\":true,\"creditAchieved\":1,\"fractionSatisfied\":1}}",
-                                                    "rendererState": "{\"__componentNeedingUpdateValue\":null,\"/a\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"2\"},\"childrenInstructions\":[]},\"/__mathinput_KXh6glTyP5\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":1,\"valueHasBeenValidated\":true,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":2,\"rawRendererValue\":\"2\"},\"childrenInstructions\":[]},\"/_answer1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\",\"stateValues\":{\"value\":2}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":1,\"justSubmitted\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_KXh6glTyP5\",\"effectiveName\":\"/__mathinput_KXh6glTyP5\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/_p1\":{\"stateValues\":{\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence1\",\"firstInd\":1,\"lastInd\":1,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"Enter: \",{\"componentName\":\"/a\",\"effectiveName\":\"/a\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/a\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/a\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/a\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/a\"}}},\". \",{\"componentName\":\"/_answer1\",\"effectiveName\":\"/_answer1\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer1\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/_question1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Question 3\",\"titlePrefix\":\"Question 3\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":1,\"collapsible\":false,\"open\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false},\"childrenInstructions\":[\"Question 1C \",{\"componentName\":\"/_p1\",\"effectiveName\":\"/_p1\",\"componentType\":\"p\",\"rendererType\":\"p\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_p1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_p1\"}}}]},\"/_document1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"disabled\":false,\"fixed\":null,\"fixLocation\":false,\"titleChildName\":null,\"title\":\"\",\"level\":0,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":1,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"containerTag\":\"div\"},\"childrenInstructions\":[{\"componentName\":\"/_question1\",\"effectiveName\":\"/_question1\",\"componentType\":\"question\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_question1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_question1\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_question1\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_question1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_question1\"}}}]}}",
-                                                    "docId": "sel2c",
-                                                    "attemptNumber": 1,
-                                                    "activityId": "apple",
-                                                    "onSubmission": false
-                                                },
-                                                "creditAchieved": 1,
-                                                "initialQuestionCounter": 3
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "creditAchieved": 1,
-                                "initialQuestionCounter": 3
-                            }
-                        ]
+                        "type": "singleDoc",
+                        "id": "sel2b",
+                        "parentId": "sel2",
+                        "initialVariant": 8813,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2c",
+                        "parentId": "sel2",
+                        "initialVariant": 305570,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 2,
+                        "currentVariant": 6,
+                        "previousVariants": [3, 6],
+                        "initialQuestionCounter": 1,
+                        "doenetState": null
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2d",
+                        "parentId": "sel2",
+                        "initialVariant": 468285,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null
                     }
                 ],
-                "creditAchieved": 0.5
+                "attemptNumber": 2,
+                "selectedChildren": [
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2c",
+                        "parentId": "sel2",
+                        "initialVariant": 305570,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 2,
+                        "currentVariant": 6,
+                        "previousVariants": [3, 6],
+                        "initialQuestionCounter": 1,
+                        "doenetState": null
+                    }
+                ],
+                "previousSelections": ["sel2c", "sel2c"],
+                "initialQuestionCounter": 1
+            },
+            {
+                "type": "select",
+                "id": "sel",
+                "parentId": "seq",
+                "initialVariant": 674202,
+                "creditAchieved": 0.5,
+                "maxCreditAchieved": 0.5,
+                "allChildren": [
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|1",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 1,
+                        "maxCreditAchieved": 1,
+                        "attemptNumber": 1,
+                        "currentVariant": 1,
+                        "previousVariants": [1],
+                        "initialQuestionCounter": 2,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 1,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|2",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 2,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|3",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 3,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|4",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 4,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|5",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 1,
+                        "maxCreditAchieved": 1,
+                        "attemptNumber": 1,
+                        "currentVariant": 5,
+                        "previousVariants": [5],
+                        "initialQuestionCounter": 2,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 5,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|6",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 6,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|7",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 7,
+                        "previousVariants": [7],
+                        "initialQuestionCounter": 1,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 7,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|8",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 8,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|9",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 9,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|10",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 10,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|1",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 1,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|2",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 2,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|3",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 3,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|4",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 4,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|5",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 5,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|6",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 6,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|7",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 7,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|8",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 8,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|9",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 9,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|10",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 10,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|11",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 11,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|12",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 12,
+                        "previousVariants": [12],
+                        "initialQuestionCounter": 3,
+                        "doenetState": null,
+                        "restrictToVariantSlice": {
+                            "idx": 12,
+                            "numSlices": 12
+                        }
+                    }
+                ],
+                "attemptNumber": 2,
+                "selectedChildren": [
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|5",
+                        "parentId": "sel",
+                        "initialVariant": 220521,
+                        "creditAchieved": 1,
+                        "maxCreditAchieved": 1,
+                        "attemptNumber": 1,
+                        "currentVariant": 5,
+                        "previousVariants": [5],
+                        "initialQuestionCounter": 2,
+                        "doenetState": {
+                            "cid": "bafkreihsl5tcsjhj6g5ffdibj3ssse7fpnsgib6qqddlb7sw7ljlycpzwq",
+                            "coreInfo": "{\"generatedVariantString\":\"{\\\"index\\\":5,\\\"name\\\":\\\"e\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_document1\\\"},\\\"subvariants\\\":[{\\\"index\\\":5,\\\"name\\\":\\\"e\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem1\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[7],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence1\\\"}}]}]}\",\"allPossibleVariants\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"rendererTypesInDocument\":[\"section\",\"answer\",\"mathInput\",\"vector\",\"math\",\"number\",\"text\"],\"documentToRender\":{\"componentName\":\"/_document1\",\"effectiveName\":\"/_document1\",\"componentType\":\"document\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_document1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_document1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_document1\"}}}}",
+                            "coreState": "{\"/_selectfromsequence1\":{\"errorMessage\":\"\",\"selectedValues\":[7],\"selectedIndices\":[7]},\"/__mathinput_KXh6glTyP5\":{\"rawRendererValue\":\"4\",\"lastValueForDisplay\":4,\"immediateValue\":4,\"immediateValueChanged\":true,\"dontUpdateRawValueInDefinition\":false,\"valueChanged\":true,\"value\":4},\"/__math_d9bmzOvKly\":{\"expressionWithCodes\":4},\"/_answer1\":{\"justSubmitted\":true,\"creditAchieved\":1,\"responseHasBeenSubmitted\":true,\"numSubmittedResponses\":1,\"submittedResponses\":{\"0\":4,\"mergeObject\":true},\"submittedResponsesComponentType\":[\"math\"],\"creditAchievedDependenciesAtSubmit\":\"DyEEXaBSatsKpauKq05+i9z0vGE=\",\"numSubmissions\":3,\"hasBeenCorrect\":true},\"/_document1\":{\"theme\":\"light\"},\"/__award_XTZPmlFGuS\":{\"awarded\":true,\"creditAchieved\":1,\"fractionSatisfied\":1}}",
+                            "rendererState": "{\"__componentNeedingUpdateValue\":null,\"/__mathinput_KXh6glTyP5\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":1,\"valueHasBeenValidated\":true,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":4,\"rawRendererValue\":\"4\"},\"childrenInstructions\":[]},\"/_answer1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\",\"stateValues\":{\"value\":4}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":1,\"justSubmitted\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_KXh6glTyP5\",\"effectiveName\":\"/__mathinput_KXh6glTyP5\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/__number_SYcjAbK4Kk\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"7\"},\"childrenInstructions\":[]},\"/_problem1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 2\",\"titlePrefix\":\"Problem 2\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":1,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence1\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"2+2=\",{\"componentName\":\"/_answer1\",\"effectiveName\":\"/_answer1\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer1\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}},{\"componentName\":\"/__number_SYcjAbK4Kk\",\"effectiveName\":\"/__number_SYcjAbK4Kk\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_SYcjAbK4Kk\"}}}]},\"/_document1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"disabled\":false,\"fixed\":null,\"fixLocation\":false,\"titleChildName\":null,\"title\":\"\",\"level\":0,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":1,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"containerTag\":\"div\"},\"childrenInstructions\":[{\"componentName\":\"/_problem1\",\"effectiveName\":\"/_problem1\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem1\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem1\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem1\"}}}]}}",
+                            "docId": "qrf|5",
+                            "attemptNumber": 1,
+                            "activityId": "apple",
+                            "onSubmission": true
+                        },
+                        "restrictToVariantSlice": {
+                            "idx": 5,
+                            "numSlices": 10
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "abc|12",
+                        "parentId": "sel",
+                        "initialVariant": 666083,
+                        "creditAchieved": 0,
+                        "maxCreditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 12,
+                        "previousVariants": [12],
+                        "initialQuestionCounter": 3,
+                        "doenetState": {
+                            "cid": "bafkreidbscui3reafhxqwqq43rxabvqzk4n3ezykklv4u6vrl4svyrkkte",
+                            "coreInfo": "{\"generatedVariantString\":\"{\\\"index\\\":12,\\\"name\\\":\\\"l\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_document1\\\"},\\\"subvariants\\\":[{\\\"index\\\":12,\\\"name\\\":\\\"l\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem1\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[3],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence1\\\"}}]},{\\\"index\\\":12,\\\"name\\\":\\\"l\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem2\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[2],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence2\\\"}}]}]}\",\"allPossibleVariants\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\",\"k\",\"l\"],\"rendererTypesInDocument\":[\"section\",\"answer\",\"mathInput\",\"vector\",\"math\",\"number\",\"text\"],\"documentToRender\":{\"componentName\":\"/_document1\",\"effectiveName\":\"/_document1\",\"componentType\":\"document\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_document1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_document1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_document1\"}}}}",
+                            "coreState": "{\"/_selectfromsequence1\":{\"errorMessage\":\"\",\"selectedValues\":[3],\"selectedIndices\":[3]},\"/_selectfromsequence2\":{\"errorMessage\":\"\",\"selectedValues\":[2],\"selectedIndices\":[2]},\"/__mathinput_KXh6glTyP5\":{\"rawRendererValue\":\"6\",\"lastValueForDisplay\":6,\"immediateValue\":6,\"immediateValueChanged\":true,\"dontUpdateRawValueInDefinition\":false,\"valueChanged\":true,\"value\":6},\"/__math_d9bmzOvKly\":{\"expressionWithCodes\":2},\"/_answer1\":{\"justSubmitted\":true,\"creditAchieved\":0,\"responseHasBeenSubmitted\":true,\"numSubmittedResponses\":1,\"submittedResponses\":{\"0\":6,\"mergeObject\":true},\"submittedResponsesComponentType\":[\"math\"],\"creditAchievedDependenciesAtSubmit\":\"fD5kLv1bViCQ8bBPAokbpf5sBKE=\",\"numSubmissions\":1},\"/__mathinput_h2Krc-ovWn\":{\"rawRendererValue\":\"\",\"lastValueForDisplay\":\"＿\"},\"/__math_aKY8kD0utp\":{\"expressionWithCodes\":8},\"/_answer2\":{\"justSubmitted\":false},\"/_document1\":{\"theme\":\"light\"},\"/__award_XTZPmlFGuS\":{\"awarded\":false,\"creditAchieved\":0,\"fractionSatisfied\":0}}",
+                            "rendererState": "{\"__componentNeedingUpdateValue\":null,\"/__mathinput_KXh6glTyP5\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":0,\"valueHasBeenValidated\":true,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":6,\"rawRendererValue\":\"6\"},\"childrenInstructions\":[]},\"/_answer1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\",\"stateValues\":{\"value\":6}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":0,\"justSubmitted\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_KXh6glTyP5\",\"effectiveName\":\"/__mathinput_KXh6glTyP5\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/__number_SYcjAbK4Kk\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"3\"},\"childrenInstructions\":[]},\"/_problem1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 3\",\"titlePrefix\":\"Problem 3\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":0,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence1\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"1+1=\",{\"componentName\":\"/_answer1\",\"effectiveName\":\"/_answer1\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer1\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}},{\"componentName\":\"/__number_SYcjAbK4Kk\",\"effectiveName\":\"/__number_SYcjAbK4Kk\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_SYcjAbK4Kk\"}}}]},\"/__mathinput_h2Krc-ovWn\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":0,\"valueHasBeenValidated\":false,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":\"＿\",\"rawRendererValue\":\"\"},\"childrenInstructions\":[]},\"/_answer2\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_h2Krc-ovWn\",\"stateValues\":{\"value\":\"＿\"}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":0,\"justSubmitted\":false,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_h2Krc-ovWn\",\"effectiveName\":\"/__mathinput_h2Krc-ovWn\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer2\"}}}]},\"/__number_3QEzfiwkYT\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"2\"},\"childrenInstructions\":[]},\"/_problem2\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 4\",\"titlePrefix\":\"Problem 4\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":false,\"showCorrectness\":true,\"creditAchieved\":0,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence2\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"4+4=\",{\"componentName\":\"/_answer2\",\"effectiveName\":\"/_answer2\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer2\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer2\"}}},{\"componentName\":\"/__number_3QEzfiwkYT\",\"effectiveName\":\"/__number_3QEzfiwkYT\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_3QEzfiwkYT\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_3QEzfiwkYT\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_3QEzfiwkYT\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_3QEzfiwkYT\"}}}]},\"/_document1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"disabled\":false,\"fixed\":null,\"fixLocation\":false,\"titleChildName\":null,\"title\":\"\",\"level\":0,\"justSubmitted\":false,\"showCorrectness\":true,\"creditAchieved\":0,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"containerTag\":\"div\"},\"childrenInstructions\":[{\"componentName\":\"/_problem1\",\"effectiveName\":\"/_problem1\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem1\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem1\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem1\"}}},{\"componentName\":\"/_problem2\",\"effectiveName\":\"/_problem2\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem2\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem2\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem2\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem2\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem2\"}}}]}}",
+                            "docId": "abc|12",
+                            "attemptNumber": 1,
+                            "activityId": "apple",
+                            "onSubmission": true
+                        },
+                        "restrictToVariantSlice": {
+                            "idx": 12,
+                            "numSlices": 12
+                        }
+                    }
+                ],
+                "previousSelections": ["qrf|7", "qrf|1", "qrf|5", "abc|12"],
+                "initialQuestionCounter": 2
             }
         ]
     },
-    "sourceHash": "a29660729f00b097c5d3e42bf3db45411d0675f1"
+    "sourceHash": "372925bb55564f82bcf24f0534e6f0f416924bac",
+    "onSubmission": true
 }

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -345,19 +345,35 @@ export function generateNewSubActivityAttempt({
  * Recurse through the descendants of `activityState`,
  * returning an array of the `maxCreditAchieved` of the latest single document activities,
  * or of select activities that select a single document.
+ *
+ * If `unshuffled` is `true`, then use the original order from sequences
+ * rather than (the potentially shuffled) `orderedChildren`
  */
 export function extractActivityItemCredit(
     activityState: ActivityState,
-): { id: string; score: number; maxScore: number; docId?: string }[] {
+    nPrevInShuffleOrder = 0,
+): {
+    id: string;
+    score: number;
+    maxScore: number;
+    docId?: string;
+    shuffledOrder: number;
+}[] {
     switch (activityState.type) {
         case "singleDoc": {
-            return extractSingleDocItemCredit(activityState);
+            return extractSingleDocItemCredit(
+                activityState,
+                nPrevInShuffleOrder,
+            );
         }
         case "select": {
-            return extractSelectItemCredit(activityState);
+            return extractSelectItemCredit(activityState, nPrevInShuffleOrder);
         }
         case "sequence": {
-            return extractSequenceItemCredit(activityState);
+            return extractSequenceItemCredit(
+                activityState,
+                nPrevInShuffleOrder,
+            );
         }
     }
 }

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -343,20 +343,31 @@ export function generateNewSubActivityAttempt({
 
 /**
  * Recurse through the descendants of `activityState`,
- * returning an array of the `maxCreditAchieved` of the latest single document activities,
+ * returning an array of score information of the latest single document activities,
  * or of select activities that select a single document.
  *
- * If `unshuffled` is `true`, then use the original order from sequences
- * rather than (the potentially shuffled) `orderedChildren`
+ * The `nPrevInShuffleOrder` argument is only used in recursion to track the order of documents.
+ *
+ * The order of the results is based on the original order from sequences
+ * (i.e., ignoring any shuffling)
+ *
+ * Return an array of objects with the fields:
+ * - id: the id of the activity corresponding to the item. It is typically the document,
+ *   though it will be the id of the select when it selects a single document.
+ * - docId: the id of the document. It may be undefined if the first attempt has not yet generated.
+ * - score: the score (credit achieved, between 0 and 1) of the latest submission of the document
+ * - maxScore, the maximum score of the document achieved during the current attempt of the base activity
+ * - shuffleOrder: the (1-based) index of this item using the order
+ *   determined from (the potentially shuffled) `orderedChildren` of sequences
  */
 export function extractActivityItemCredit(
     activityState: ActivityState,
     nPrevInShuffleOrder = 0,
 ): {
     id: string;
+    docId?: string;
     score: number;
     maxScore: number;
-    docId?: string;
     shuffledOrder: number;
 }[] {
     switch (activityState.type) {

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -66,11 +66,11 @@ export function activityStateReducer(
         }
         case "set": {
             if (action.allowSaveState) {
-                const scoreByItem = extractActivityItemCredit(action.state);
+                const itemScores = extractActivityItemCredit(action.state);
                 window.postMessage({
                     score: action.state.creditAchieved,
                     maxScore: action.state.maxCreditAchieved,
-                    scoreByItem,
+                    itemScores,
                     subject: "SPLICE.reportScoreByItem",
                     activityId: action.baseId,
                 });
@@ -102,15 +102,14 @@ export function activityStateReducer(
             }
 
             if (action.allowSaveState) {
-                const scoreByItem = extractActivityItemCredit(newActivityState);
-
+                const itemScores = extractActivityItemCredit(newActivityState);
                 if (firstAttempt) {
                     // If first attempt, no need to save state.
                     // Just send score by item to indicate how many items are in the activity
                     window.postMessage({
                         score: newActivityState.creditAchieved,
                         maxScore: newActivityState.maxCreditAchieved,
-                        scoreByItem,
+                        itemScores,
                         subject: "SPLICE.reportScoreByItem",
                         activityId: action.baseId,
                     });
@@ -119,11 +118,11 @@ export function activityStateReducer(
 
                     if (action.id && action.id !== state.id) {
                         // determine the item number for which we are generating a new attempt
-                        const scoreByItemOld = extractActivityItemCredit(state);
+                        const itemScoresOld = extractActivityItemCredit(state);
 
                         newAttemptForItem = {
                             newAttemptForItem:
-                                scoreByItemOld.findIndex(
+                                itemScoresOld.findIndex(
                                     (s) =>
                                         s.id === action.id ||
                                         s.docId === action.id,
@@ -143,7 +142,7 @@ export function activityStateReducer(
                         },
                         score: newActivityState.creditAchieved,
                         maxScore: newActivityState.maxCreditAchieved,
-                        scoreByItem,
+                        itemScores,
                         subject: "SPLICE.reportScoreAndState",
                         activityId: action.baseId,
                         newAttempt: true,
@@ -158,7 +157,7 @@ export function activityStateReducer(
             const newActivityState = updateSingleDocState(action, state);
 
             if (action.allowSaveState) {
-                const scoreByItem = extractActivityItemCredit(newActivityState);
+                const itemScores = extractActivityItemCredit(newActivityState);
 
                 const sourceHash = hash(newActivityState.source);
 
@@ -184,7 +183,7 @@ export function activityStateReducer(
                     },
                     score: newActivityState.creditAchieved,
                     maxScore: newActivityState.maxCreditAchieved,
-                    scoreByItem,
+                    itemScores,
                     subject: "SPLICE.reportScoreAndState",
                     activityId: action.baseId,
                 });

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -629,9 +629,9 @@ export function generateNewSingleDocAttemptForMultiSelect({
 }
 
 /**
- * Recurse through the descendants of `activityState`,
- * returning an array of the `creditAchieved` and `maxCreditAchieved` of the latest single document activities,
- * or of select activities that select a single document.
+//  * Recurse through the descendants of `activityState`,
+//  * returning an array of score information of the latest single document activities,
+//  * or of select activities that select a single document.
  */
 export function extractSelectItemCredit(
     activityState: SelectState,

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -635,9 +635,23 @@ export function generateNewSingleDocAttemptForMultiSelect({
  */
 export function extractSelectItemCredit(
     activityState: SelectState,
-): { id: string; score: number; maxScore: number; docId?: string }[] {
+    nPrevInShuffleOrder = 0,
+): {
+    id: string;
+    score: number;
+    maxScore: number;
+    docId?: string;
+    shuffledOrder: number;
+}[] {
     if (activityState.attemptNumber === 0) {
-        return [{ id: activityState.id, score: 0, maxScore: 0 }];
+        return [
+            {
+                id: activityState.id,
+                score: 0,
+                maxScore: 0,
+                shuffledOrder: nPrevInShuffleOrder + 1,
+            },
+        ];
     }
     if (
         activityState.source.numToSelect === 1 &&
@@ -650,12 +664,16 @@ export function extractSelectItemCredit(
                 score: activityState.creditAchieved,
                 maxScore: activityState.maxCreditAchieved,
                 docId: activityState.selectedChildren[0].id,
+                shuffledOrder: nPrevInShuffleOrder + 1,
             },
         ];
     } else {
-        return activityState.selectedChildren.flatMap((state) =>
-            extractActivityItemCredit(state),
-        );
+        let nPrev = nPrevInShuffleOrder;
+        return activityState.selectedChildren.flatMap((state) => {
+            const next = extractActivityItemCredit(state, nPrev);
+            nPrev += next.length;
+            return next;
+        });
     }
 }
 

--- a/src/Activity/sequenceState.ts
+++ b/src/Activity/sequenceState.ts
@@ -338,7 +338,7 @@ export function generateNewSequenceAttempt({
 
 /**
  * Recurse through the descendants of `activityState`,
- * returning an array of the `creditAchieved` and `maxCreditAchieved` of the latest single document activities,
+ * returning an array of score information of the latest single document activities,
  * or of select activities that select a single document.
  */
 export function extractSequenceItemCredit(

--- a/src/Activity/singleDocState.ts
+++ b/src/Activity/singleDocState.ts
@@ -259,7 +259,7 @@ export function generateNewSingleDocAttempt({
 }
 
 /**
- * Return the credit achieved of this single doc activity or an empty array if it is a description.
+ * Return score information of this single doc activity or an empty array if it is a description.
  */
 export function extractSingleDocItemCredit(
     activityState: SingleDocState,

--- a/src/Activity/singleDocState.ts
+++ b/src/Activity/singleDocState.ts
@@ -263,7 +263,14 @@ export function generateNewSingleDocAttempt({
  */
 export function extractSingleDocItemCredit(
     activityState: SingleDocState,
-): { id: string; score: number; maxScore: number; docId: string }[] {
+    nPrevInShuffleOrder = 0,
+): {
+    id: string;
+    score: number;
+    maxScore: number;
+    docId: string;
+    shuffledOrder: number;
+}[] {
     if (activityState.source.isDescription) {
         return [];
     } else {
@@ -273,6 +280,7 @@ export function extractSingleDocItemCredit(
                 score: activityState.creditAchieved,
                 maxScore: activityState.maxCreditAchieved,
                 docId: activityState.id,
+                shuffledOrder: nPrevInShuffleOrder + 1,
             },
         ];
     }

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -106,8 +106,14 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreByItem",
                 maxScore: 0,
                 score: 0,
-                scoreByItem: [
-                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
+                itemScores: [
+                    {
+                        id: "doc5",
+                        maxScore: 0,
+                        score: 0,
+                        docId: "doc5",
+                        shuffledOrder: 1,
+                    },
                 ],
                 activityId: "newId",
             },
@@ -177,8 +183,14 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreByItem",
                 maxScore: 0,
                 score: 0,
-                scoreByItem: [
-                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
+                itemScores: [
+                    {
+                        id: "doc5",
+                        maxScore: 0,
+                        score: 0,
+                        docId: "doc5",
+                        shuffledOrder: 1,
+                    },
                 ],
                 activityId: "newId",
             },
@@ -213,8 +225,14 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0,
                 score: 0,
-                scoreByItem: [
-                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
+                itemScores: [
+                    {
+                        id: "doc5",
+                        maxScore: 0,
+                        score: 0,
+                        docId: "doc5",
+                        shuffledOrder: 1,
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -278,12 +296,13 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0.2,
                 score: 0.2,
-                scoreByItem: [
+                itemScores: [
                     {
                         id: "doc5",
                         maxScore: 0.2,
                         score: 0.2,
                         docId: "doc5",
+                        shuffledOrder: 1,
                     },
                 ],
                 state: {
@@ -323,12 +342,13 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0.2,
                 score: 0.1,
-                scoreByItem: [
+                itemScores: [
                     {
                         id: "doc5",
                         maxScore: 0.2,
                         score: 0.1,
                         docId: "doc5",
+                        shuffledOrder: 1,
                     },
                 ],
                 state: {
@@ -368,12 +388,13 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0.3,
                 score: 0.3,
-                scoreByItem: [
+                itemScores: [
                     {
                         id: "doc5",
                         maxScore: 0.3,
                         score: 0.3,
                         docId: "doc5",
+                        shuffledOrder: 1,
                     },
                 ],
                 state: {
@@ -413,8 +434,14 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0,
                 score: 0,
-                scoreByItem: [
-                    { id: "doc5", maxScore: 0, score: 0, docId: "doc5" },
+                itemScores: [
+                    {
+                        id: "doc5",
+                        maxScore: 0,
+                        score: 0,
+                        docId: "doc5",
+                        shuffledOrder: 1,
+                    },
                 ],
                 state: {
                     state: pruneActivityStateForSave(state),
@@ -452,12 +479,13 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0.1,
                 score: 0.1,
-                scoreByItem: [
+                itemScores: [
                     {
                         id: "doc5",
                         maxScore: 0.1,
                         score: 0.1,
                         docId: "doc5",
+                        shuffledOrder: 1,
                     },
                 ],
                 state: {
@@ -497,12 +525,13 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: 0.5,
                 score: 0.5,
-                scoreByItem: [
+                itemScores: [
                     {
                         id: "doc5",
                         maxScore: 0.5,
                         score: 0.5,
                         docId: "doc5",
+                        shuffledOrder: 1,
                     },
                 ],
                 state: {
@@ -586,26 +615,16 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: maxCreditAchieved,
                 score: creditAchieved,
-                scoreByItem: [
-                    {
-                        id: docIds[0],
-                        maxScore: docCredits[0],
-                        score: docLatestCredits[0],
-                        docId: docIds[0],
-                    },
-                    {
-                        id: docIds[1],
-                        maxScore: docCredits[1],
-                        score: docLatestCredits[1],
-                        docId: docIds[1],
-                    },
-                    {
-                        id: docIds[2],
-                        maxScore: docCredits[2],
-                        score: docLatestCredits[2],
-                        docId: docIds[2],
-                    },
-                ],
+                itemScores: state.allChildren.map((child) => {
+                    const idx = docIds.indexOf(child.id);
+                    return {
+                        id: docIds[idx],
+                        score: docLatestCredits[idx],
+                        maxScore: docCredits[idx],
+                        docId: docIds[idx],
+                        shuffledOrder: idx + 1,
+                    };
+                }),
                 state: {
                     state: pruneActivityStateForSave(state),
                 },
@@ -791,6 +810,8 @@ describe("Activity reducer tests", () => {
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
+        const childIds = source.items.map((c) => c.id);
+
         const state0 = initializeActivityState({
             source: source,
             variant: 5,
@@ -910,7 +931,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             newAttempt: true,
-            newAttemptForItem: 1,
+            newAttemptForItem: childIds.indexOf(docIds[0]) + 1,
             spy,
         });
 
@@ -1007,7 +1028,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             newAttempt: true,
-            newAttemptForItem: 2,
+            newAttemptForItem: childIds.indexOf(docIds[1]) + 1,
             spy,
         });
 
@@ -1120,20 +1141,16 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: maxCreditAchieved,
                 score: creditAchieved,
-                scoreByItem: [
-                    {
-                        id: selIds[0],
-                        maxScore: selCredits[0],
-                        score: selLatestCredits[0],
-                        docId: docIds[0],
-                    },
-                    {
-                        id: selIds[1],
-                        maxScore: selCredits[1],
-                        score: selLatestCredits[1],
-                        docId: docIds[1],
-                    },
-                ],
+                itemScores: state.allChildren.map((child) => {
+                    const idx = selIds.indexOf(child.id);
+                    return {
+                        id: selIds[idx],
+                        score: selLatestCredits[idx],
+                        maxScore: selCredits[idx],
+                        docId: docIds[idx],
+                        shuffledOrder: idx + 1,
+                    };
+                }),
                 state: {
                     state: pruneActivityStateForSave(state),
                 },
@@ -1377,6 +1394,8 @@ describe("Activity reducer tests", () => {
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
+        const childIds = source.items.map((c) => c.id);
+
         const state0 = initializeActivityState({
             source: source,
             variant: 5,
@@ -1543,7 +1562,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             newAttempt: true,
-            newAttemptForItem: 2,
+            newAttemptForItem: childIds.indexOf(selIds[1]) + 1,
             spy,
         });
 
@@ -1645,7 +1664,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             newAttempt: true,
-            newAttemptForItem: 1,
+            newAttemptForItem: childIds.indexOf(selIds[0]) + 1,
             spy,
         });
 
@@ -1687,6 +1706,8 @@ describe("Activity reducer tests", () => {
         const source = seq2sel as SequenceSource;
 
         const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const childIds = source.items.map((c) => c.id);
 
         const state0 = initializeActivityState({
             source: source,
@@ -1854,7 +1875,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             newAttempt: true,
-            newAttemptForItem: 2,
+            newAttemptForItem: childIds.indexOf(selIds[1]) + 1,
             spy,
         });
 
@@ -1956,7 +1977,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             newAttempt: true,
-            newAttemptForItem: 1,
+            newAttemptForItem: childIds.indexOf(selIds[0]) + 1,
             spy,
         });
 
@@ -2057,18 +2078,20 @@ describe("Activity reducer tests", () => {
                 subject: "SPLICE.reportScoreAndState",
                 maxScore: maxCreditAchieved,
                 score: creditAchieved,
-                scoreByItem: [
+                itemScores: [
                     {
                         id: docIds[0],
                         maxScore: docCredits[0],
                         score: docLatestCredits[0],
                         docId: docIds[0],
+                        shuffledOrder: 1,
                     },
                     {
                         id: docIds[1],
                         maxScore: docCredits[1],
                         score: docLatestCredits[1],
                         docId: docIds[1],
+                        shuffledOrder: 2,
                     },
                 ],
                 state: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,11 +79,12 @@ export type reportStateMessage = {
     activityId: string;
     score: number;
     maxScore: number;
-    scoreByItem: {
+    itemScores: {
         id: string;
         score: number;
         maxScore: number;
         docId?: string;
+        shuffledOrder: number;
     }[];
     state: ExportedActivityState;
     newAttempt?: boolean;
@@ -102,13 +103,14 @@ export function isReportStateMessage(obj: unknown): obj is reportStateMessage {
         typeof typeObj.activityId === "string" &&
         typeof typeObj.score === "number" &&
         typeof typeObj.maxScore === "number" &&
-        Array.isArray(typeObj.scoreByItem) &&
-        typeObj.scoreByItem.every(
+        Array.isArray(typeObj.itemScores) &&
+        typeObj.itemScores.every(
             (item) =>
                 typeof item.id === "string" &&
                 typeof item.score === "number" &&
                 typeof item.maxScore === "number" &&
-                (item.docId === undefined || typeof item.docId === "string"),
+                (item.docId === undefined || typeof item.docId === "string") &&
+                typeof item.shuffledOrder === "number",
         ) &&
         isExportedActivityState(typeObj.state) &&
         (typeObj.newAttempt === undefined ||
@@ -123,11 +125,12 @@ export type reportScoreByItemMessage = {
     activityId: string;
     score: number;
     maxScore: number;
-    scoreByItem: {
+    itemScores: {
         id: string;
         score: number;
         maxScore: number;
         docId?: string;
+        shuffledOrder: number;
     }[];
 };
 
@@ -145,13 +148,14 @@ export function isReportScoreByItemMessage(
         typeof typeObj.activityId === "string" &&
         typeof typeObj.score === "number" &&
         typeof typeObj.maxScore === "number" &&
-        Array.isArray(typeObj.scoreByItem) &&
-        typeObj.scoreByItem.every(
+        Array.isArray(typeObj.itemScores) &&
+        typeObj.itemScores.every(
             (item) =>
                 typeof item.id === "string" &&
                 typeof item.score === "number" &&
                 typeof item.maxScore === "number" &&
-                (item.docId === undefined || typeof item.docId === "string"),
+                (item.docId === undefined || typeof item.docId === "string") &&
+                typeof item.shuffledOrder === "number",
         )
     );
 }


### PR DESCRIPTION
In SPLICE.reportScoreByItem and SPLICE.reportScoreAndState messages, the array of item scores is now in the order that would occur if all selects had `shuffle` set to `false`. A `shuffledOrder` field specifies their shuffled order.