### PR TITLE
separate doenet states from activity state

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -312,7 +312,7 @@ function App() {
 
                 <div>
                     Assignment credit:{" "}
-                    {(activityState?.state.creditAchieved ?? 0) * 100}%
+                    {(activityState?.activityState.creditAchieved ?? 0) * 100}%
                 </div>
                 <div>
                     Credit by item, latest attempt:
@@ -326,7 +326,7 @@ function App() {
                 </div>
                 <div>
                     Assignment attempt number:{" "}
-                    {activityState?.state.attemptNumber ?? 0 + 1}
+                    {activityState?.activityState.attemptNumber ?? 0 + 1}
                 </div>
             </div>
 

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -15,6 +15,7 @@ export function Activity({
     darkMode = "light",
     showAnswerTitles = false,
     state,
+    doenetStates,
     reportScoreAndStateCallback,
     checkRender,
     checkHidden,
@@ -35,6 +36,7 @@ export function Activity({
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
     state: ActivityState;
+    doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
@@ -65,6 +67,7 @@ export function Activity({
                     darkMode={darkMode}
                     showAnswerTitles={showAnswerTitles}
                     state={state}
+                    doenetStates={doenetStates}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
@@ -89,6 +92,7 @@ export function Activity({
                     darkMode={darkMode}
                     showAnswerTitles={showAnswerTitles}
                     state={state}
+                    doenetStates={doenetStates}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}
@@ -114,6 +118,7 @@ export function Activity({
                     darkMode={darkMode}
                     showAnswerTitles={showAnswerTitles}
                     state={state}
+                    doenetStates={doenetStates}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
                     checkRender={checkRender}
                     checkHidden={checkHidden}

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -15,6 +15,7 @@ export function SelectActivity({
     darkMode = "light",
     showAnswerTitles = false,
     state,
+    doenetStates,
     reportScoreAndStateCallback,
     checkRender,
     checkHidden,
@@ -35,6 +36,7 @@ export function SelectActivity({
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
     state: SelectState;
+    doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
@@ -58,6 +60,7 @@ export function SelectActivity({
             <Activity
                 key={activity.id}
                 state={activity}
+                doenetStates={doenetStates}
                 flags={flags}
                 baseId={baseId}
                 forceDisable={forceDisable}

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -15,6 +15,7 @@ export function SequenceActivity({
     darkMode = "light",
     showAnswerTitles = false,
     state,
+    doenetStates,
     reportScoreAndStateCallback,
     checkRender,
     checkHidden,
@@ -35,6 +36,7 @@ export function SequenceActivity({
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
     state: SequenceState;
+    doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
@@ -57,6 +59,7 @@ export function SequenceActivity({
             <Activity
                 key={activity.id}
                 state={activity}
+                doenetStates={doenetStates}
                 flags={flags}
                 baseId={baseId}
                 forceDisable={forceDisable}

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -15,6 +15,7 @@ export function SingleDocActivity({
     darkMode = "light",
     showAnswerTitles = false,
     state,
+    doenetStates,
     reportScoreAndStateCallback,
     checkRender,
     checkHidden,
@@ -34,6 +35,7 @@ export function SingleDocActivity({
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
     state: SingleDocState;
+    doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
@@ -53,8 +55,13 @@ export function SingleDocActivity({
         string,
         unknown
     > | null>(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        state.doenetState as Record<string, any> | null,
+        (state.doenetStateIdx === null
+            ? null
+            : (doenetStates[state.doenetStateIdx] ?? null)) as Record<
+            string,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any
+        > | null,
     );
 
     const [requestedVariantIndex, setRequestedVariantIndex] = useState(
@@ -87,8 +94,13 @@ export function SingleDocActivity({
         setAttemptNumber(state.attemptNumber);
 
         setInitialDoenetState(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            state.doenetState as Record<string, any> | null,
+            (state.doenetStateIdx === null
+                ? null
+                : (doenetStates[state.doenetStateIdx] ?? null)) as Record<
+                string,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                any
+            > | null,
         );
 
         setRequestedVariantIndex(state.currentVariant);

--- a/src/Activity/sequenceState.ts
+++ b/src/Activity/sequenceState.ts
@@ -377,25 +377,18 @@ export function extractSequenceItemCredit(
 /**
  * Remove all references to source from `activityState`, forming an instance of `ActivityStateNoSource`
  * that is intended to be saved to a database.
- *
- * If `clearDoenetState` is `true`, then also remove the `doenetState` in single documents.
- *
- * Even if `clearDoenetState` is `false``, still clear `doenetState` on all `allChildren`.
- * In this way, the (potentially large) DoenetML state is saved
- * only where needed to reconstitute the activity state.
  */
 export function pruneSequenceStateForSave(
     activityState: SequenceState,
-    clearDoenetState: boolean,
 ): SequenceStateNoSource {
     const { source: _source, ...newState } = { ...activityState };
 
     const allChildren = newState.allChildren.map((child) =>
-        pruneActivityStateForSave(child, true),
+        pruneActivityStateForSave(child),
     );
 
     const orderedChildren = newState.orderedChildren.map((child) =>
-        pruneActivityStateForSave(child, clearDoenetState),
+        pruneActivityStateForSave(child),
     );
 
     return { ...newState, allChildren, orderedChildren };

--- a/src/Activity/singleDocState.ts
+++ b/src/Activity/singleDocState.ts
@@ -44,8 +44,8 @@ export type SingleDocState = {
     currentVariant: number;
     /** A list of the the variants selected in all attempts, ordered by attempt number */
     previousVariants: number[];
-    /** A json object containing the state needed to reconstitute the activity of the current attempt */
-    doenetState: unknown;
+    /** Index indicating where to retrieve the json object of state needed to reconstitute the activity */
+    doenetStateIdx: number | null;
     /** The value of the question counter set for the beginning of this activity */
     initialQuestionCounter: number;
     /** See {@link RestrictToVariantSlice} */
@@ -160,7 +160,7 @@ export function initializeSingleDocState({
         currentVariant: 0,
         previousVariants: [],
         initialQuestionCounter: 0,
-        doenetState: null,
+        doenetStateIdx: null,
         restrictToVariantSlice,
     };
 }
@@ -243,7 +243,7 @@ export function generateNewSingleDocAttempt({
         attemptNumber: state.attemptNumber + 1,
         currentVariant: selectedVariant,
         previousVariants: [...state.previousVariants, selectedVariant],
-        doenetState: null,
+        doenetStateIdx: null,
         initialQuestionCounter,
     };
 
@@ -279,22 +279,13 @@ export function extractSingleDocItemCredit(
 /**
  * Remove all references to source from `activityState`, forming an instance of `ActivityStateNoSource`
  * that is intended to be saved to a database.
- *
- * If `clearDoenetState` is `true`, then also remove the `doenetState`.
- *
- * Even if `clearDoenetState` is `false`, still clear `doenetState` on all but the latest attempt,
- * so the (potentially large) DoenetML state is saved
- * only where needed to reconstitute the activity state.
  */
 export function pruneSingleDocStateForSave(
     activityState: SingleDocState,
-    clearDoenetState: boolean,
 ): SingleDocStateNoSource {
     const { source: _source, ...newState } = { ...activityState };
 
-    const doenetState = clearDoenetState ? null : newState.doenetState;
-
-    return { ...newState, doenetState };
+    return newState;
 }
 
 /** Reverse the effect of `pruneSingleDocStateForSave by adding back adding back references to the source */

--- a/src/test/activityState.test.ts
+++ b/src/test/activityState.test.ts
@@ -22,7 +22,6 @@ import sel0 from "./testSources/sel0.json";
 import seq0 from "./testSources/seq0.json";
 import seq2Sel0 from "./testSources/seq2Sel0.json";
 import seqSel0Sel from "./testSources/seqSel0Sel.json";
-import sel2seq from "./testSources/sel2seq.json";
 
 import {
     SelectSource,
@@ -66,7 +65,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
         const doc2State: SingleDocState = {
             type: "singleDoc",
@@ -81,7 +80,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
 
         const select1State: SelectState = {
@@ -111,7 +110,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
         const doc4State: SingleDocState = {
             type: "singleDoc",
@@ -126,7 +125,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
         const doc5State: SingleDocState = {
             type: "singleDoc",
@@ -141,7 +140,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
 
         const select2State: SelectState = {
@@ -186,7 +185,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
         const doc2StatePruned: SingleDocStateNoSource = {
             type: "singleDoc",
@@ -199,7 +198,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
 
         const select1StatePruned: SelectStateNoSource = {
@@ -226,7 +225,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
         const doc4StatePruned: SingleDocStateNoSource = {
             type: "singleDoc",
@@ -239,7 +238,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
         const doc5StatePruned: SingleDocStateNoSource = {
             type: "singleDoc",
@@ -252,7 +251,7 @@ describe("Activity state tests", () => {
             currentVariant: 0,
             attemptNumber: 0,
             previousVariants: [],
-            doenetState: null,
+            doenetStateIdx: null,
         };
 
         const select2StatePruned: SelectStateNoSource = {
@@ -332,7 +331,7 @@ describe("Activity state tests", () => {
             initialVariant: docVariant,
             creditAchieved: 0,
             attemptNumber: 0,
-            doenetState: null,
+            doenetStateIdx: null,
             initialQuestionCounter: 0,
             currentVariant: 0,
             previousVariants: [],
@@ -347,7 +346,7 @@ describe("Activity state tests", () => {
             initialVariant: docVariant,
             creditAchieved: 0,
             attemptNumber: 0,
-            doenetState: null,
+            doenetStateIdx: null,
             initialQuestionCounter: 0,
             currentVariant: 0,
             previousVariants: [],
@@ -362,7 +361,7 @@ describe("Activity state tests", () => {
             initialVariant: docVariant,
             creditAchieved: 0,
             attemptNumber: 0,
-            doenetState: null,
+            doenetStateIdx: null,
             initialQuestionCounter: 0,
             currentVariant: 0,
             previousVariants: [],
@@ -377,7 +376,7 @@ describe("Activity state tests", () => {
             initialVariant: docVariant,
             creditAchieved: 0,
             attemptNumber: 0,
-            doenetState: null,
+            doenetStateIdx: null,
             initialQuestionCounter: 0,
             currentVariant: 0,
             previousVariants: [],
@@ -704,9 +703,6 @@ describe("Activity state tests", () => {
 
     it("return number of documents", () => {
         expect(getNumItems(seq2sel as SequenceSource)).eq(2);
-
-        // upper bound when ambiguous
-        expect(getNumItems(sel2seq as SelectSource)).eq(3);
 
         expect(getNumItems(selMult2docs as SelectSource)).eq(2);
         expect(getNumItems(selMult1doc as SelectSource)).eq(3);

--- a/src/test/generateVariants.test.ts
+++ b/src/test/generateVariants.test.ts
@@ -726,7 +726,7 @@ describe("Test of generating activity variants", () => {
             allQuestionVariants2.push(questionVariants2);
 
             const docIds1 = ["doc4", "doc5"];
-            const docIds2 = ["doc3", "doc2", "doc1"];
+            const docIds2 = ["doc3", "doc1"];
 
             const seqIds = ["seq1", "seq2"];
 
@@ -764,8 +764,8 @@ describe("Test of generating activity variants", () => {
                         questionVariants1[j].push(doc.currentVariant);
                     }
                 } else {
-                    expect(sequence.orderedChildren.length).eq(3);
-                    for (let j = 0; j < 3; j++) {
+                    expect(sequence.orderedChildren.length).eq(2);
+                    for (let j = 0; j < 2; j++) {
                         const doc = sequence.orderedChildren[
                             j
                         ] as SingleDocState;
@@ -786,7 +786,7 @@ describe("Test of generating activity variants", () => {
             for (let i = 0; i < 2; i++) {
                 expect(questionVariants1[i].length).eq(32);
             }
-            for (let i = 0; i < 3; i++) {
+            for (let i = 0; i < 2; i++) {
                 expect(questionVariants2[i].length).eq(8);
             }
 
@@ -813,18 +813,11 @@ describe("Test of generating activity variants", () => {
                 [1, 2, 3],
             );
 
-            for (let i = 0; i < 4; i++) {
-                expect(
-                    questionVariants2[1]
-                        .slice(2 * i, 2 * i + 2)
-                        .sort((a, b) => a - b),
-                ).eqls([1, 2]);
-            }
-            expect(questionVariants2[2]).eqls(Array(8).fill(1));
+            expect(questionVariants2[1]).eqls(Array(8).fill(1));
         }
 
-        // at least 40 of the 120 questions should have been shuffled away from their original position
-        expect(numReordered).greaterThan(40);
+        // at least 20 of the 80 questions should have been shuffled away from their original position
+        expect(numReordered).greaterThan(20);
 
         // different question variants for each base variant
         expect(allQuestionVariants1[0]).not.eqls(allQuestionVariants1[1]);

--- a/src/test/itemAttempts.test.ts
+++ b/src/test/itemAttempts.test.ts
@@ -10,7 +10,7 @@ import { SequenceSource, SequenceState } from "../Activity/sequenceState";
 import {
     gatherDocumentStructure,
     generateNewActivityAttempt,
-    generateNewSubActivityAttempt,
+    generateNewSingleDocSubAttempt,
     initializeActivityState,
 } from "../Activity/activityState";
 import { SingleDocState } from "../Activity/singleDocState";
@@ -62,8 +62,8 @@ describe("Test of generating new item attempts", () => {
 
                     questionVariants[questionIdx].push(doc.currentVariant);
 
-                    state = generateNewSubActivityAttempt({
-                        id: docId,
+                    state = generateNewSingleDocSubAttempt({
+                        singleDocId: docId,
                         state,
                         numActivityVariants,
                         initialQuestionCounter: 1, // not right, but doesn't matter for this test
@@ -150,8 +150,8 @@ describe("Test of generating new item attempts", () => {
                     for (let k = 0; k < 3; k++) {
                         const docIds = state.selectedChildren.map((a) => a.id);
 
-                        state = generateNewSubActivityAttempt({
-                            id: docIds[j],
+                        state = generateNewSingleDocSubAttempt({
+                            singleDocId: docIds[j],
                             state,
                             numActivityVariants,
                             initialQuestionCounter: 1, // not right, but doesn't matter for this test
@@ -241,8 +241,8 @@ describe("Test of generating new item attempts", () => {
                     for (let k = 0; k < 15; k++) {
                         const docIds = state.selectedChildren.map((a) => a.id);
 
-                        state = generateNewSubActivityAttempt({
-                            id: docIds[j],
+                        state = generateNewSingleDocSubAttempt({
+                            singleDocId: docIds[j],
                             state,
                             numActivityVariants,
                             initialQuestionCounter: 1, // not right, but doesn't matter for this test
@@ -350,8 +350,8 @@ describe("Test of generating new item attempts", () => {
 
                         questionIds[selIdx].push(docExtendedId);
 
-                        state = generateNewSubActivityAttempt({
-                            id: docState.id,
+                        state = generateNewSingleDocSubAttempt({
+                            singleDocId: docState.id,
                             state,
                             numActivityVariants,
                             initialQuestionCounter: 1, // not right, but doesn't matter for this test
@@ -440,8 +440,8 @@ describe("Test of generating new item attempts", () => {
                     questionIds[selIdx].push(docExtendedId);
 
                     if (i < 2) {
-                        state = generateNewSubActivityAttempt({
-                            id: docState.id,
+                        state = generateNewSingleDocSubAttempt({
+                            singleDocId: docState.id,
                             state,
                             numActivityVariants,
                             initialQuestionCounter: 1, // not right, but doesn't matter for this test
@@ -537,8 +537,8 @@ describe("Test of generating new item attempts", () => {
                     for (let k = 0; k < 5; k++) {
                         const docIds = state.selectedChildren.map((a) => a.id);
 
-                        state = generateNewSubActivityAttempt({
-                            id: docIds[j],
+                        state = generateNewSingleDocSubAttempt({
+                            singleDocId: docIds[j],
                             state,
                             numActivityVariants,
                             initialQuestionCounter: 1, // not right, but doesn't matter for this test

--- a/src/test/testSources/sel2seq.json
+++ b/src/test/testSources/sel2seq.json
@@ -45,15 +45,6 @@
                     "baseComponentCounts": { "question": 1 }
                 },
                 {
-                    "id": "doc2",
-                    "type": "singleDoc",
-                    "isDescription": false,
-                    "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
-                    "numVariants": 2,
-                    "baseComponentCounts": { "question": 1 }
-                },
-                {
                     "id": "doc1",
                     "type": "singleDoc",
                     "isDescription": false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export function isSingleDocReportStateMessage(
     );
 }
 
-export type reportStateMessage = {
+export type ReportStateMessage = {
     subject: "SPLICE.reportScoreAndState";
     activityId: string;
     score: number;
@@ -87,10 +87,11 @@ export type reportStateMessage = {
     state: ExportedActivityState;
     newAttempt?: boolean;
     newAttemptForItem?: number;
+    newDoenetStateIdx?: number;
 };
 
-export function isReportStateMessage(obj: unknown): obj is reportStateMessage {
-    const typeObj = obj as reportStateMessage;
+export function isReportStateMessage(obj: unknown): obj is ReportStateMessage {
+    const typeObj = obj as ReportStateMessage;
 
     return (
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -112,11 +113,13 @@ export function isReportStateMessage(obj: unknown): obj is reportStateMessage {
         (typeObj.newAttempt === undefined ||
             typeof typeObj.newAttempt === "boolean") &&
         (typeObj.newAttemptForItem === undefined ||
-            typeof typeObj.newAttemptForItem === "number")
+            typeof typeObj.newAttemptForItem === "number") &&
+        (typeObj.newDoenetStateIdx === undefined ||
+            typeof typeObj.newDoenetStateIdx === "number")
     );
 }
 
-export type reportScoreByItemMessage = {
+export type ReportScoreByItemMessage = {
     subject: "SPLICE.reportScoreByItem";
     activityId: string;
     score: number;
@@ -130,8 +133,8 @@ export type reportScoreByItemMessage = {
 
 export function isReportScoreByItemMessage(
     obj: unknown,
-): obj is reportScoreByItemMessage {
-    const typeObj = obj as reportScoreByItemMessage;
+): obj is ReportScoreByItemMessage {
+    const typeObj = obj as ReportScoreByItemMessage;
 
     return (
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition


### PR DESCRIPTION
This PR separates the DoenetML states from the rendered documents into an array of the serialized DoenetML state, in the order of the (possible shuffled) rendered sequence of documents. SPLICE.reportScoreAndState messages now indicate which Doenet state was modified so an app can know which state it needs to save. This change will allow apps to save DoenetML states for each doc separately, saving database storage requirements as only changed document needs to be saved.

For simplicity, we now restrict selects to always return the same number of documents for each option. Previously, one could select from, for example, a sequence of length 2 and a sequence of length 3. Violating this constraint causes an error to be thrown.