### PR TITLE
track attempts and disable new attempt buttons when reach max allowed

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -22,6 +22,7 @@ function App() {
         itemLevelAttempts: boolean;
         activityLevelAttempts: boolean;
         paginate: boolean;
+        maxAttempts: number;
     } = {
         requestedVariantIndex: 1,
         showCorrectness: true,
@@ -31,6 +32,7 @@ function App() {
         itemLevelAttempts: true,
         activityLevelAttempts: true,
         paginate: false,
+        maxAttempts: 2,
     };
 
     const [controlsVisible, setControlsVisible] = useState(false);
@@ -46,6 +48,7 @@ function App() {
         itemLevelAttempts,
         activityLevelAttempts,
         paginate,
+        maxAttempts,
     } = testSettings;
 
     let controls = null;
@@ -78,7 +81,6 @@ function App() {
                 <hr />
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={showCorrectness}
@@ -97,7 +99,6 @@ function App() {
                 </div>
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={readOnly}
@@ -115,7 +116,6 @@ function App() {
                 </div>
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={showFeedback}
@@ -133,7 +133,6 @@ function App() {
                 </div>
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={showHints}
@@ -151,7 +150,6 @@ function App() {
                 </div>
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={itemLevelAttempts}
@@ -170,7 +168,6 @@ function App() {
                 </div>
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={activityLevelAttempts}
@@ -189,7 +186,6 @@ function App() {
                 </div>
                 <div>
                     <label>
-                        {" "}
                         <input
                             type="checkbox"
                             checked={paginate}
@@ -203,6 +199,29 @@ function App() {
                             }}
                         />
                         Paginate
+                    </label>
+                </div>
+                <div>
+                    <label>
+                        Max attempts:
+                        <input
+                            type="text"
+                            style={{ marginLeft: "5px" }}
+                            defaultValue={maxAttempts}
+                            onChange={(e) => {
+                                const numValue = parseInt(e.target.value);
+                                if (
+                                    Number.isInteger(numValue) &&
+                                    numValue >= 0
+                                ) {
+                                    setTestSettings((was) => {
+                                        const newObj = { ...was };
+                                        newObj.maxAttempts = numValue;
+                                        return newObj;
+                                    });
+                                }
+                            }}
+                        />
                     </label>
                 </div>
             </div>
@@ -346,6 +365,7 @@ function App() {
                 activityId={activityId}
                 itemLevelAttempts={itemLevelAttempts}
                 activityLevelAttempts={activityLevelAttempts}
+                maxAttemptsAllowed={maxAttempts}
             />
         </div>
     );

--- a/dev/testInitialState.json
+++ b/dev/testInitialState.json
@@ -1,29 +1,29 @@
 {
-    "state": {
+    "activityState": {
         "type": "sequence",
         "id": "seq",
         "parentId": null,
-        "initialVariant": 210305,
-        "creditAchieved": 0.25,
+        "initialVariant": 640554,
+        "creditAchieved": 0,
         "allChildren": [
             {
                 "type": "select",
                 "id": "sel",
                 "parentId": "seq",
-                "initialVariant": 674202,
-                "creditAchieved": 0.5,
+                "initialVariant": 120384,
+                "creditAchieved": 0,
                 "allChildren": [
                     {
                         "type": "singleDoc",
                         "id": "qrf|1",
                         "parentId": "sel",
-                        "initialVariant": 220521,
-                        "creditAchieved": 1,
-                        "attemptNumber": 1,
-                        "currentVariant": 1,
-                        "previousVariants": [1],
-                        "initialQuestionCounter": 2,
-                        "doenetState": null,
+                        "initialVariant": 573303,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 1,
                             "numSlices": 10
@@ -33,13 +33,13 @@
                         "type": "singleDoc",
                         "id": "qrf|2",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 2,
                             "numSlices": 10
@@ -49,13 +49,13 @@
                         "type": "singleDoc",
                         "id": "qrf|3",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "attemptNumber": 1,
+                        "currentVariant": 3,
+                        "previousVariants": [3],
+                        "initialQuestionCounter": 3,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 3,
                             "numSlices": 10
@@ -65,13 +65,13 @@
                         "type": "singleDoc",
                         "id": "qrf|4",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "attemptNumber": 1,
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 3,
+                        "doenetStateIdx": 1,
                         "restrictToVariantSlice": {
                             "idx": 4,
                             "numSlices": 10
@@ -81,13 +81,13 @@
                         "type": "singleDoc",
                         "id": "qrf|5",
                         "parentId": "sel",
-                        "initialVariant": 220521,
-                        "creditAchieved": 1,
-                        "attemptNumber": 1,
-                        "currentVariant": 5,
-                        "previousVariants": [5],
-                        "initialQuestionCounter": 2,
-                        "doenetState": null,
+                        "initialVariant": 573303,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 5,
                             "numSlices": 10
@@ -97,13 +97,13 @@
                         "type": "singleDoc",
                         "id": "qrf|6",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 6,
                             "numSlices": 10
@@ -113,13 +113,13 @@
                         "type": "singleDoc",
                         "id": "qrf|7",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
-                        "attemptNumber": 1,
-                        "currentVariant": 7,
-                        "previousVariants": [7],
-                        "initialQuestionCounter": 1,
-                        "doenetState": null,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 7,
                             "numSlices": 10
@@ -129,13 +129,13 @@
                         "type": "singleDoc",
                         "id": "qrf|8",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 8,
                             "numSlices": 10
@@ -145,13 +145,13 @@
                         "type": "singleDoc",
                         "id": "qrf|9",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 9,
                             "numSlices": 10
@@ -161,13 +161,13 @@
                         "type": "singleDoc",
                         "id": "qrf|10",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 10,
                             "numSlices": 10
@@ -177,13 +177,13 @@
                         "type": "singleDoc",
                         "id": "abc|1",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 1,
                             "numSlices": 12
@@ -193,13 +193,13 @@
                         "type": "singleDoc",
                         "id": "abc|2",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 2,
                             "numSlices": 12
@@ -209,13 +209,13 @@
                         "type": "singleDoc",
                         "id": "abc|3",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 3,
                             "numSlices": 12
@@ -225,13 +225,13 @@
                         "type": "singleDoc",
                         "id": "abc|4",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 4,
                             "numSlices": 12
@@ -241,13 +241,13 @@
                         "type": "singleDoc",
                         "id": "abc|5",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 5,
                             "numSlices": 12
@@ -257,13 +257,13 @@
                         "type": "singleDoc",
                         "id": "abc|6",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "attemptNumber": 1,
+                        "currentVariant": 6,
+                        "previousVariants": [6],
+                        "initialQuestionCounter": 1,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 6,
                             "numSlices": 12
@@ -273,13 +273,13 @@
                         "type": "singleDoc",
                         "id": "abc|7",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 7,
                             "numSlices": 12
@@ -289,13 +289,13 @@
                         "type": "singleDoc",
                         "id": "abc|8",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 8,
                             "numSlices": 12
@@ -305,13 +305,13 @@
                         "type": "singleDoc",
                         "id": "abc|9",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 9,
                             "numSlices": 12
@@ -321,13 +321,13 @@
                         "type": "singleDoc",
                         "id": "abc|10",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 10,
                             "numSlices": 12
@@ -337,13 +337,13 @@
                         "type": "singleDoc",
                         "id": "abc|11",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 11,
                             "numSlices": 12
@@ -353,226 +353,152 @@
                         "type": "singleDoc",
                         "id": "abc|12",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
-                        "attemptNumber": 1,
-                        "currentVariant": 12,
-                        "previousVariants": [12],
-                        "initialQuestionCounter": 3,
-                        "doenetState": null,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 12,
                             "numSlices": 12
                         }
                     }
                 ],
-                "attemptNumber": 2,
+                "attemptNumber": 1,
                 "selectedChildren": [
                     {
                         "type": "singleDoc",
-                        "id": "qrf|5",
+                        "id": "abc|6",
                         "parentId": "sel",
-                        "initialVariant": 220521,
-                        "creditAchieved": 1,
+                        "initialVariant": 396719,
+                        "creditAchieved": 0,
                         "attemptNumber": 1,
-                        "currentVariant": 5,
-                        "previousVariants": [5],
-                        "initialQuestionCounter": 2,
-                        "doenetState": null,
+                        "currentVariant": 6,
+                        "previousVariants": [6],
+                        "initialQuestionCounter": 1,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
-                            "idx": 5,
+                            "idx": 6,
+                            "numSlices": 12
+                        }
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "qrf|4",
+                        "parentId": "sel",
+                        "initialVariant": 573303,
+                        "creditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 3,
+                        "doenetStateIdx": 1,
+                        "restrictToVariantSlice": {
+                            "idx": 4,
                             "numSlices": 10
                         }
+                    }
+                ],
+                "previousSelections": ["abc|6", "qrf|3", "qrf|4"],
+                "initialQuestionCounter": 3
+            },
+            {
+                "type": "select",
+                "id": "sel2",
+                "parentId": "seq",
+                "initialVariant": 574127,
+                "creditAchieved": 0,
+                "allChildren": [
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2a",
+                        "parentId": "sel2",
+                        "initialVariant": 933832,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null
                     },
                     {
                         "type": "singleDoc",
-                        "id": "abc|12",
-                        "parentId": "sel",
-                        "initialVariant": 666083,
+                        "id": "sel2b",
+                        "parentId": "sel2",
+                        "initialVariant": 154678,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2c",
+                        "parentId": "sel2",
+                        "initialVariant": 516352,
                         "creditAchieved": 0,
                         "attemptNumber": 1,
-                        "currentVariant": 12,
-                        "previousVariants": [12],
-                        "initialQuestionCounter": 3,
-                        "doenetState": null,
-                        "restrictToVariantSlice": {
-                            "idx": 12,
-                            "numSlices": 12
-                        }
-                    }
-                ],
-                "previousSelections": ["qrf|7", "qrf|1", "qrf|5", "abc|12"],
-                "initialQuestionCounter": 2
-            },
-            {
-                "type": "select",
-                "id": "sel2",
-                "parentId": "seq",
-                "initialVariant": 269772,
-                "creditAchieved": 0,
-                "allChildren": [
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2a",
-                        "parentId": "sel2",
-                        "initialVariant": 543722,
-                        "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null
-                    },
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2b",
-                        "parentId": "sel2",
-                        "initialVariant": 8813,
-                        "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null
-                    },
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2c",
-                        "parentId": "sel2",
-                        "initialVariant": 305570,
-                        "creditAchieved": 0,
-                        "attemptNumber": 2,
-                        "currentVariant": 6,
-                        "previousVariants": [3, 6],
-                        "initialQuestionCounter": 1,
-                        "doenetState": null
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 4,
+                        "doenetStateIdx": null
                     },
                     {
                         "type": "singleDoc",
                         "id": "sel2d",
                         "parentId": "sel2",
-                        "initialVariant": 468285,
+                        "initialVariant": 546636,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null
+                        "doenetStateIdx": null
                     }
                 ],
-                "attemptNumber": 2,
+                "attemptNumber": 1,
                 "selectedChildren": [
                     {
                         "type": "singleDoc",
                         "id": "sel2c",
                         "parentId": "sel2",
-                        "initialVariant": 305570,
+                        "initialVariant": 516352,
                         "creditAchieved": 0,
-                        "attemptNumber": 2,
-                        "currentVariant": 6,
-                        "previousVariants": [3, 6],
-                        "initialQuestionCounter": 1,
-                        "doenetState": null
+                        "attemptNumber": 1,
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 4,
+                        "doenetStateIdx": null
                     }
                 ],
-                "previousSelections": ["sel2c", "sel2c"],
-                "initialQuestionCounter": 1
+                "previousSelections": ["sel2c"],
+                "initialQuestionCounter": 4
             }
         ],
-        "attemptNumber": 2,
+        "attemptNumber": 1,
         "orderedChildren": [
-            {
-                "type": "select",
-                "id": "sel2",
-                "parentId": "seq",
-                "initialVariant": 269772,
-                "creditAchieved": 0,
-                "allChildren": [
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2a",
-                        "parentId": "sel2",
-                        "initialVariant": 543722,
-                        "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null
-                    },
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2b",
-                        "parentId": "sel2",
-                        "initialVariant": 8813,
-                        "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null
-                    },
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2c",
-                        "parentId": "sel2",
-                        "initialVariant": 305570,
-                        "creditAchieved": 0,
-                        "attemptNumber": 2,
-                        "currentVariant": 6,
-                        "previousVariants": [3, 6],
-                        "initialQuestionCounter": 1,
-                        "doenetState": null
-                    },
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2d",
-                        "parentId": "sel2",
-                        "initialVariant": 468285,
-                        "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null
-                    }
-                ],
-                "attemptNumber": 2,
-                "selectedChildren": [
-                    {
-                        "type": "singleDoc",
-                        "id": "sel2c",
-                        "parentId": "sel2",
-                        "initialVariant": 305570,
-                        "creditAchieved": 0,
-                        "attemptNumber": 2,
-                        "currentVariant": 6,
-                        "previousVariants": [3, 6],
-                        "initialQuestionCounter": 1,
-                        "doenetState": null
-                    }
-                ],
-                "previousSelections": ["sel2c", "sel2c"],
-                "initialQuestionCounter": 1
-            },
             {
                 "type": "select",
                 "id": "sel",
                 "parentId": "seq",
-                "initialVariant": 674202,
-                "creditAchieved": 0.5,
+                "initialVariant": 120384,
+                "creditAchieved": 0,
                 "allChildren": [
                     {
                         "type": "singleDoc",
                         "id": "qrf|1",
                         "parentId": "sel",
-                        "initialVariant": 220521,
-                        "creditAchieved": 1,
-                        "attemptNumber": 1,
-                        "currentVariant": 1,
-                        "previousVariants": [1],
-                        "initialQuestionCounter": 2,
-                        "doenetState": null,
+                        "initialVariant": 573303,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 1,
                             "numSlices": 10
@@ -582,13 +508,13 @@
                         "type": "singleDoc",
                         "id": "qrf|2",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 2,
                             "numSlices": 10
@@ -598,13 +524,13 @@
                         "type": "singleDoc",
                         "id": "qrf|3",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "attemptNumber": 1,
+                        "currentVariant": 3,
+                        "previousVariants": [3],
+                        "initialQuestionCounter": 3,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 3,
                             "numSlices": 10
@@ -614,13 +540,13 @@
                         "type": "singleDoc",
                         "id": "qrf|4",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "attemptNumber": 1,
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 3,
+                        "doenetStateIdx": 1,
                         "restrictToVariantSlice": {
                             "idx": 4,
                             "numSlices": 10
@@ -630,13 +556,13 @@
                         "type": "singleDoc",
                         "id": "qrf|5",
                         "parentId": "sel",
-                        "initialVariant": 220521,
-                        "creditAchieved": 1,
-                        "attemptNumber": 1,
-                        "currentVariant": 5,
-                        "previousVariants": [5],
-                        "initialQuestionCounter": 2,
-                        "doenetState": null,
+                        "initialVariant": 573303,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 5,
                             "numSlices": 10
@@ -646,13 +572,13 @@
                         "type": "singleDoc",
                         "id": "qrf|6",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 6,
                             "numSlices": 10
@@ -662,13 +588,13 @@
                         "type": "singleDoc",
                         "id": "qrf|7",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
-                        "attemptNumber": 1,
-                        "currentVariant": 7,
-                        "previousVariants": [7],
-                        "initialQuestionCounter": 1,
-                        "doenetState": null,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 7,
                             "numSlices": 10
@@ -678,13 +604,13 @@
                         "type": "singleDoc",
                         "id": "qrf|8",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 8,
                             "numSlices": 10
@@ -694,13 +620,13 @@
                         "type": "singleDoc",
                         "id": "qrf|9",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 9,
                             "numSlices": 10
@@ -710,13 +636,13 @@
                         "type": "singleDoc",
                         "id": "qrf|10",
                         "parentId": "sel",
-                        "initialVariant": 220521,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 10,
                             "numSlices": 10
@@ -726,13 +652,13 @@
                         "type": "singleDoc",
                         "id": "abc|1",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 1,
                             "numSlices": 12
@@ -742,13 +668,13 @@
                         "type": "singleDoc",
                         "id": "abc|2",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 2,
                             "numSlices": 12
@@ -758,13 +684,13 @@
                         "type": "singleDoc",
                         "id": "abc|3",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 3,
                             "numSlices": 12
@@ -774,13 +700,13 @@
                         "type": "singleDoc",
                         "id": "abc|4",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 4,
                             "numSlices": 12
@@ -790,13 +716,13 @@
                         "type": "singleDoc",
                         "id": "abc|5",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 5,
                             "numSlices": 12
@@ -806,13 +732,13 @@
                         "type": "singleDoc",
                         "id": "abc|6",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
-                        "attemptNumber": 0,
-                        "currentVariant": 0,
-                        "previousVariants": [],
-                        "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "attemptNumber": 1,
+                        "currentVariant": 6,
+                        "previousVariants": [6],
+                        "initialQuestionCounter": 1,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 6,
                             "numSlices": 12
@@ -822,13 +748,13 @@
                         "type": "singleDoc",
                         "id": "abc|7",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 7,
                             "numSlices": 12
@@ -838,13 +764,13 @@
                         "type": "singleDoc",
                         "id": "abc|8",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 8,
                             "numSlices": 12
@@ -854,13 +780,13 @@
                         "type": "singleDoc",
                         "id": "abc|9",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 9,
                             "numSlices": 12
@@ -870,13 +796,13 @@
                         "type": "singleDoc",
                         "id": "abc|10",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 10,
                             "numSlices": 12
@@ -886,13 +812,13 @@
                         "type": "singleDoc",
                         "id": "abc|11",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
                         "attemptNumber": 0,
                         "currentVariant": 0,
                         "previousVariants": [],
                         "initialQuestionCounter": 0,
-                        "doenetState": null,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 11,
                             "numSlices": 12
@@ -902,77 +828,146 @@
                         "type": "singleDoc",
                         "id": "abc|12",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 396719,
                         "creditAchieved": 0,
-                        "attemptNumber": 1,
-                        "currentVariant": 12,
-                        "previousVariants": [12],
-                        "initialQuestionCounter": 3,
-                        "doenetState": null,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
                             "idx": 12,
                             "numSlices": 12
                         }
                     }
                 ],
-                "attemptNumber": 2,
+                "attemptNumber": 1,
                 "selectedChildren": [
                     {
                         "type": "singleDoc",
-                        "id": "qrf|5",
+                        "id": "abc|6",
                         "parentId": "sel",
-                        "initialVariant": 220521,
-                        "creditAchieved": 1,
+                        "initialVariant": 396719,
+                        "creditAchieved": 0,
                         "attemptNumber": 1,
-                        "currentVariant": 5,
-                        "previousVariants": [5],
-                        "initialQuestionCounter": 2,
-                        "doenetState": {
-                            "cid": "bafkreihsl5tcsjhj6g5ffdibj3ssse7fpnsgib6qqddlb7sw7ljlycpzwq",
-                            "coreInfo": "{\"generatedVariantString\":\"{\\\"index\\\":5,\\\"name\\\":\\\"e\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_document1\\\"},\\\"subvariants\\\":[{\\\"index\\\":5,\\\"name\\\":\\\"e\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem1\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[7],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence1\\\"}}]}]}\",\"allPossibleVariants\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"rendererTypesInDocument\":[\"section\",\"answer\",\"mathInput\",\"vector\",\"math\",\"number\",\"text\"],\"documentToRender\":{\"componentName\":\"/_document1\",\"effectiveName\":\"/_document1\",\"componentType\":\"document\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_document1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_document1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_document1\"}}}}",
-                            "coreState": "{\"/_selectfromsequence1\":{\"errorMessage\":\"\",\"selectedValues\":[7],\"selectedIndices\":[7]},\"/__mathinput_KXh6glTyP5\":{\"rawRendererValue\":\"4\",\"lastValueForDisplay\":4,\"immediateValue\":4,\"immediateValueChanged\":true,\"dontUpdateRawValueInDefinition\":false,\"valueChanged\":true,\"value\":4},\"/__math_d9bmzOvKly\":{\"expressionWithCodes\":4},\"/_answer1\":{\"justSubmitted\":true,\"creditAchieved\":1,\"responseHasBeenSubmitted\":true,\"numSubmittedResponses\":1,\"submittedResponses\":{\"0\":4,\"mergeObject\":true},\"submittedResponsesComponentType\":[\"math\"],\"creditAchievedDependenciesAtSubmit\":\"DyEEXaBSatsKpauKq05+i9z0vGE=\",\"numSubmissions\":3,\"hasBeenCorrect\":true},\"/_document1\":{\"theme\":\"light\"},\"/__award_XTZPmlFGuS\":{\"awarded\":true,\"creditAchieved\":1,\"fractionSatisfied\":1}}",
-                            "rendererState": "{\"__componentNeedingUpdateValue\":null,\"/__mathinput_KXh6glTyP5\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":1,\"valueHasBeenValidated\":true,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":4,\"rawRendererValue\":\"4\"},\"childrenInstructions\":[]},\"/_answer1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\",\"stateValues\":{\"value\":4}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":1,\"justSubmitted\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_KXh6glTyP5\",\"effectiveName\":\"/__mathinput_KXh6glTyP5\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/__number_SYcjAbK4Kk\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"7\"},\"childrenInstructions\":[]},\"/_problem1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 2\",\"titlePrefix\":\"Problem 2\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":1,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence1\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"2+2=\",{\"componentName\":\"/_answer1\",\"effectiveName\":\"/_answer1\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer1\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}},{\"componentName\":\"/__number_SYcjAbK4Kk\",\"effectiveName\":\"/__number_SYcjAbK4Kk\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_SYcjAbK4Kk\"}}}]},\"/_document1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"disabled\":false,\"fixed\":null,\"fixLocation\":false,\"titleChildName\":null,\"title\":\"\",\"level\":0,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":1,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"containerTag\":\"div\"},\"childrenInstructions\":[{\"componentName\":\"/_problem1\",\"effectiveName\":\"/_problem1\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem1\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem1\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem1\"}}}]}}",
-                            "docId": "qrf|5",
-                            "attemptNumber": 1,
-                            "activityId": "apple",
-                            "onSubmission": true
-                        },
+                        "currentVariant": 6,
+                        "previousVariants": [6],
+                        "initialQuestionCounter": 1,
+                        "doenetStateIdx": null,
                         "restrictToVariantSlice": {
-                            "idx": 5,
-                            "numSlices": 10
+                            "idx": 6,
+                            "numSlices": 12
                         }
                     },
                     {
                         "type": "singleDoc",
-                        "id": "abc|12",
+                        "id": "qrf|4",
                         "parentId": "sel",
-                        "initialVariant": 666083,
+                        "initialVariant": 573303,
                         "creditAchieved": 0,
                         "attemptNumber": 1,
-                        "currentVariant": 12,
-                        "previousVariants": [12],
+                        "currentVariant": 4,
+                        "previousVariants": [4],
                         "initialQuestionCounter": 3,
-                        "doenetState": {
-                            "cid": "bafkreidbscui3reafhxqwqq43rxabvqzk4n3ezykklv4u6vrl4svyrkkte",
-                            "coreInfo": "{\"generatedVariantString\":\"{\\\"index\\\":12,\\\"name\\\":\\\"l\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_document1\\\"},\\\"subvariants\\\":[{\\\"index\\\":12,\\\"name\\\":\\\"l\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem1\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[3],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence1\\\"}}]},{\\\"index\\\":12,\\\"name\\\":\\\"l\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem2\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[2],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence2\\\"}}]}]}\",\"allPossibleVariants\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\",\"k\",\"l\"],\"rendererTypesInDocument\":[\"section\",\"answer\",\"mathInput\",\"vector\",\"math\",\"number\",\"text\"],\"documentToRender\":{\"componentName\":\"/_document1\",\"effectiveName\":\"/_document1\",\"componentType\":\"document\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_document1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_document1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_document1\"}}}}",
-                            "coreState": "{\"/_selectfromsequence1\":{\"errorMessage\":\"\",\"selectedValues\":[3],\"selectedIndices\":[3]},\"/_selectfromsequence2\":{\"errorMessage\":\"\",\"selectedValues\":[2],\"selectedIndices\":[2]},\"/__mathinput_KXh6glTyP5\":{\"rawRendererValue\":\"6\",\"lastValueForDisplay\":6,\"immediateValue\":6,\"immediateValueChanged\":true,\"dontUpdateRawValueInDefinition\":false,\"valueChanged\":true,\"value\":6},\"/__math_d9bmzOvKly\":{\"expressionWithCodes\":2},\"/_answer1\":{\"justSubmitted\":true,\"creditAchieved\":0,\"responseHasBeenSubmitted\":true,\"numSubmittedResponses\":1,\"submittedResponses\":{\"0\":6,\"mergeObject\":true},\"submittedResponsesComponentType\":[\"math\"],\"creditAchievedDependenciesAtSubmit\":\"fD5kLv1bViCQ8bBPAokbpf5sBKE=\",\"numSubmissions\":1},\"/__mathinput_h2Krc-ovWn\":{\"rawRendererValue\":\"\",\"lastValueForDisplay\":\"＿\"},\"/__math_aKY8kD0utp\":{\"expressionWithCodes\":8},\"/_answer2\":{\"justSubmitted\":false},\"/_document1\":{\"theme\":\"light\"},\"/__award_XTZPmlFGuS\":{\"awarded\":false,\"creditAchieved\":0,\"fractionSatisfied\":0}}",
-                            "rendererState": "{\"__componentNeedingUpdateValue\":null,\"/__mathinput_KXh6glTyP5\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":0,\"valueHasBeenValidated\":true,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":6,\"rawRendererValue\":\"6\"},\"childrenInstructions\":[]},\"/_answer1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\",\"stateValues\":{\"value\":6}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":0,\"justSubmitted\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_KXh6glTyP5\",\"effectiveName\":\"/__mathinput_KXh6glTyP5\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/__number_SYcjAbK4Kk\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"3\"},\"childrenInstructions\":[]},\"/_problem1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 3\",\"titlePrefix\":\"Problem 3\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":0,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence1\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"1+1=\",{\"componentName\":\"/_answer1\",\"effectiveName\":\"/_answer1\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer1\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}},{\"componentName\":\"/__number_SYcjAbK4Kk\",\"effectiveName\":\"/__number_SYcjAbK4Kk\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_SYcjAbK4Kk\"}}}]},\"/__mathinput_h2Krc-ovWn\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":0,\"valueHasBeenValidated\":false,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":\"＿\",\"rawRendererValue\":\"\"},\"childrenInstructions\":[]},\"/_answer2\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_h2Krc-ovWn\",\"stateValues\":{\"value\":\"＿\"}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":0,\"justSubmitted\":false,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_h2Krc-ovWn\",\"effectiveName\":\"/__mathinput_h2Krc-ovWn\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_h2Krc-ovWn\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer2\"}}}]},\"/__number_3QEzfiwkYT\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"2\"},\"childrenInstructions\":[]},\"/_problem2\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 4\",\"titlePrefix\":\"Problem 4\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":false,\"showCorrectness\":true,\"creditAchieved\":0,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence2\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"4+4=\",{\"componentName\":\"/_answer2\",\"effectiveName\":\"/_answer2\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer2\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer2\"}}},{\"componentName\":\"/__number_3QEzfiwkYT\",\"effectiveName\":\"/__number_3QEzfiwkYT\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_3QEzfiwkYT\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_3QEzfiwkYT\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_3QEzfiwkYT\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_3QEzfiwkYT\"}}}]},\"/_document1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"disabled\":false,\"fixed\":null,\"fixLocation\":false,\"titleChildName\":null,\"title\":\"\",\"level\":0,\"justSubmitted\":false,\"showCorrectness\":true,\"creditAchieved\":0,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"containerTag\":\"div\"},\"childrenInstructions\":[{\"componentName\":\"/_problem1\",\"effectiveName\":\"/_problem1\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem1\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem1\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem1\"}}},{\"componentName\":\"/_problem2\",\"effectiveName\":\"/_problem2\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem2\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem2\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem2\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem2\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem2\"}}}]}}",
-                            "docId": "abc|12",
-                            "attemptNumber": 1,
-                            "activityId": "apple",
-                            "onSubmission": true
-                        },
+                        "doenetStateIdx": 1,
                         "restrictToVariantSlice": {
-                            "idx": 12,
-                            "numSlices": 12
+                            "idx": 4,
+                            "numSlices": 10
                         }
                     }
                 ],
-                "previousSelections": ["qrf|7", "qrf|1", "qrf|5", "abc|12"],
-                "initialQuestionCounter": 2
+                "previousSelections": ["abc|6", "qrf|3", "qrf|4"],
+                "initialQuestionCounter": 3
+            },
+            {
+                "type": "select",
+                "id": "sel2",
+                "parentId": "seq",
+                "initialVariant": 574127,
+                "creditAchieved": 0,
+                "allChildren": [
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2a",
+                        "parentId": "sel2",
+                        "initialVariant": 933832,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2b",
+                        "parentId": "sel2",
+                        "initialVariant": 154678,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2c",
+                        "parentId": "sel2",
+                        "initialVariant": 516352,
+                        "creditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 4,
+                        "doenetStateIdx": null
+                    },
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2d",
+                        "parentId": "sel2",
+                        "initialVariant": 546636,
+                        "creditAchieved": 0,
+                        "attemptNumber": 0,
+                        "currentVariant": 0,
+                        "previousVariants": [],
+                        "initialQuestionCounter": 0,
+                        "doenetStateIdx": null
+                    }
+                ],
+                "attemptNumber": 1,
+                "selectedChildren": [
+                    {
+                        "type": "singleDoc",
+                        "id": "sel2c",
+                        "parentId": "sel2",
+                        "initialVariant": 516352,
+                        "creditAchieved": 0,
+                        "attemptNumber": 1,
+                        "currentVariant": 4,
+                        "previousVariants": [4],
+                        "initialQuestionCounter": 4,
+                        "doenetStateIdx": null
+                    }
+                ],
+                "previousSelections": ["sel2c"],
+                "initialQuestionCounter": 4
             }
         ]
     },
     "sourceHash": "372925bb55564f82bcf24f0534e6f0f416924bac",
-    "onSubmission": true
+    "doenetStates": [
+        null,
+        {
+            "cid": "bafkreihsl5tcsjhj6g5ffdibj3ssse7fpnsgib6qqddlb7sw7ljlycpzwq",
+            "coreInfo": "{\"generatedVariantString\":\"{\\\"index\\\":4,\\\"name\\\":\\\"d\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_document1\\\"},\\\"subvariants\\\":[{\\\"index\\\":4,\\\"name\\\":\\\"d\\\",\\\"meta\\\":{\\\"createdBy\\\":\\\"/_problem1\\\"},\\\"subvariants\\\":[{\\\"indices\\\":[8],\\\"meta\\\":{\\\"createdBy\\\":\\\"/_selectfromsequence1\\\"}}]}]}\",\"allPossibleVariants\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"rendererTypesInDocument\":[\"section\",\"answer\",\"mathInput\",\"vector\",\"math\",\"number\",\"text\"],\"documentToRender\":{\"componentName\":\"/_document1\",\"effectiveName\":\"/_document1\",\"componentType\":\"document\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_document1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_document1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_document1\"}}}}",
+            "coreState": "{\"/_selectfromsequence1\":{\"errorMessage\":\"\",\"selectedValues\":[8],\"selectedIndices\":[8]},\"/__mathinput_KXh6glTyP5\":{\"rawRendererValue\":\"\",\"lastValueForDisplay\":\"＿\"},\"/__math_d9bmzOvKly\":{\"expressionWithCodes\":4},\"/_answer1\":{\"justSubmitted\":true,\"creditAchieved\":0,\"responseHasBeenSubmitted\":true,\"numSubmittedResponses\":1,\"submittedResponses\":{\"0\":\"＿\",\"mergeObject\":true},\"submittedResponsesComponentType\":[\"math\"],\"creditAchievedDependenciesAtSubmit\":\"XrOtMqA/+Szv0itkDLp7Y9CdvuU=\",\"numSubmissions\":1},\"/_document1\":{\"theme\":\"light\"},\"/__award_XTZPmlFGuS\":{\"awarded\":false,\"creditAchieved\":0,\"fractionSatisfied\":0}}",
+            "rendererState": "{\"__componentNeedingUpdateValue\":null,\"/__mathinput_KXh6glTyP5\":{\"stateValues\":{\"minWidth\":50,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"includeCheckWork\":true,\"suppressCheckwork\":false,\"creditAchieved\":0,\"valueHasBeenValidated\":true,\"showCorrectness\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"label\":\"\",\"labelHasLatex\":false,\"labelForGraph\":\"\",\"valueForDisplay\":\"＿\",\"rawRendererValue\":\"\"},\"childrenInstructions\":[]},\"/_answer1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"fixed\":false,\"fixLocation\":false,\"disabledOriginal\":false,\"showCorrectness\":true,\"inputChildren\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\"}],\"inputChildrenWithValues\":[{\"componentType\":\"mathInput\",\"componentName\":\"/__mathinput_KXh6glTyP5\",\"stateValues\":{\"value\":\"＿\"}}],\"suppressCheckwork\":false,\"delegateCheckWork\":true,\"creditAchieved\":0,\"justSubmitted\":true,\"numAttemptsLeft\":{\"objectType\":\"special-numeric\",\"stringValue\":\"Infinity\"},\"disabled\":false},\"childrenInstructions\":[{\"componentName\":\"/__mathinput_KXh6glTyP5\",\"effectiveName\":\"/__mathinput_KXh6glTyP5\",\"componentType\":\"mathInput\",\"rendererType\":\"mathInput\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateRawValue\":{\"actionName\":\"updateRawValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"updateValue\":{\"actionName\":\"updateValue\",\"componentName\":\"/__mathinput_KXh6glTyP5\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}}]},\"/__number_SYcjAbK4Kk\":{\"stateValues\":{\"renderAsMath\":false,\"draggable\":true,\"layer\":0,\"positionFromAnchor\":\"center\",\"hidden\":false,\"disabled\":false,\"fixed\":true,\"fixLocation\":false,\"selectedStyle\":{\"lineColor\":\"#648FFF\",\"lineColorWord\":\"blue\",\"lineColorDarkMode\":\"#648FFF\",\"lineColorWordDarkMode\":\"blue\",\"lineOpacity\":0.7,\"lineWidth\":4,\"lineWidthWord\":\"thick\",\"lineStyle\":\"solid\",\"lineStyleWord\":\"\",\"markerColor\":\"#648FFF\",\"markerColorWord\":\"blue\",\"markerColorDarkMode\":\"#648FFF\",\"markerColorWordDarkMode\":\"blue\",\"markerOpacity\":0.7,\"markerStyle\":\"circle\",\"markerStyleWord\":\"point\",\"markerSize\":5,\"fillColor\":\"#648FFF\",\"fillColorWord\":\"blue\",\"fillColorDarkMode\":\"#648FFF\",\"fillColorWordDarkMode\":\"blue\",\"fillOpacity\":0.3,\"textColor\":\"black\",\"textColorWord\":\"black\",\"textColorDarkMode\":\"white\",\"textColorWordDarkMode\":\"white\"},\"anchor\":[\"vector\",0,0],\"text\":\"8\"},\"childrenInstructions\":[]},\"/_problem1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"boxed\":false,\"asList\":false,\"hidden\":false,\"disabled\":false,\"fixed\":false,\"fixLocation\":false,\"inAList\":false,\"titleChildName\":null,\"title\":\"Problem 3\",\"titlePrefix\":\"Problem 3\",\"containerTag\":\"article\",\"level\":1,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":0,\"collapsible\":false,\"open\":true,\"rendered\":true,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"_compositeReplacementActiveRange\":[{\"compositeName\":\"/_selectfromsequence1\",\"firstInd\":2,\"lastInd\":2,\"asList\":true,\"potentialListComponents\":[true]}]},\"childrenInstructions\":[\"2+2=\",{\"componentName\":\"/_answer1\",\"effectiveName\":\"/_answer1\",\"componentType\":\"answer\",\"rendererType\":\"answer\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_answer1\"},\"submitAnswer\":{\"actionName\":\"submitAnswer\",\"componentName\":\"/_answer1\"}}},{\"componentName\":\"/__number_SYcjAbK4Kk\",\"effectiveName\":\"/__number_SYcjAbK4Kk\",\"componentType\":\"number\",\"rendererType\":\"number\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"moveNumber\":{\"actionName\":\"moveNumber\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberClicked\":{\"actionName\":\"numberClicked\",\"componentName\":\"/__number_SYcjAbK4Kk\"},\"numberFocused\":{\"actionName\":\"numberFocused\",\"componentName\":\"/__number_SYcjAbK4Kk\"}}}]},\"/_document1\":{\"stateValues\":{\"submitLabel\":\"Check Work\",\"submitLabelNoCorrectness\":\"Submit Response\",\"hidden\":false,\"disabled\":false,\"fixed\":null,\"fixLocation\":false,\"titleChildName\":null,\"title\":\"\",\"level\":0,\"justSubmitted\":true,\"showCorrectness\":true,\"creditAchieved\":0,\"createSubmitAllButton\":false,\"suppressAnswerSubmitButtons\":false,\"suppressCheckwork\":false,\"containerTag\":\"div\"},\"childrenInstructions\":[{\"componentName\":\"/_problem1\",\"effectiveName\":\"/_problem1\",\"componentType\":\"problem\",\"rendererType\":\"section\",\"actions\":{\"copyDoenetMLToClipboard\":{\"actionName\":\"copyDoenetMLToClipboard\",\"componentName\":\"/_problem1\"},\"submitAllAnswers\":{\"actionName\":\"submitAllAnswers\",\"componentName\":\"/_problem1\"},\"revealSection\":{\"actionName\":\"revealSection\",\"componentName\":\"/_problem1\"},\"closeSection\":{\"actionName\":\"closeSection\",\"componentName\":\"/_problem1\"},\"recordVisibilityChange\":{\"actionName\":\"recordVisibilityChange\",\"componentName\":\"/_problem1\"}}}]}}",
+            "docId": "qrf|4",
+            "attemptNumber": 1,
+            "activityId": "apple",
+            "onSubmission": true
+        }
+    ],
+    "itemAttemptNumbers": [1, 2, 1]
 }

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -7,6 +7,7 @@ import { SingleDocActivity } from "./SingleDocActivity";
 export function Activity({
     flags,
     baseId,
+    maxAttemptsAllowed,
     forceDisable = false,
     forceShowCorrectness = false,
     forceShowSolution = false,
@@ -24,10 +25,12 @@ export function Activity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
-    renderOnlyItem = null,
+    itemAttemptNumbers,
+    itemSequence,
 }: {
     flags: DoenetMLFlags;
     baseId: string;
+    maxAttemptsAllowed: number;
     forceDisable?: boolean;
     forceShowCorrectness?: boolean;
     forceShowSolution?: boolean;
@@ -48,17 +51,16 @@ export function Activity({
     hasRenderedCallback: (id: string) => void;
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
-    renderOnlyItem?: number | null;
+    itemAttemptNumbers: number[];
+    itemSequence: string[];
 }) {
     switch (state.type) {
         case "singleDoc": {
-            if (renderOnlyItem !== null && renderOnlyItem !== 1) {
-                return null;
-            }
             return (
                 <SingleDocActivity
                     flags={flags}
                     baseId={baseId}
+                    maxAttemptsAllowed={maxAttemptsAllowed}
                     forceDisable={forceDisable}
                     forceShowCorrectness={forceShowCorrectness}
                     forceShowSolution={forceShowSolution}
@@ -76,6 +78,8 @@ export function Activity({
                     hasRenderedCallback={hasRenderedCallback}
                     reportVisibility={reportVisibility}
                     reportVisibilityCallback={reportVisibilityCallback}
+                    itemAttemptNumbers={itemAttemptNumbers}
+                    itemSequence={itemSequence}
                 />
             );
         }
@@ -84,6 +88,7 @@ export function Activity({
                 <SelectActivity
                     flags={flags}
                     baseId={baseId}
+                    maxAttemptsAllowed={maxAttemptsAllowed}
                     forceDisable={forceDisable}
                     forceShowCorrectness={forceShowCorrectness}
                     forceShowSolution={forceShowSolution}
@@ -101,7 +106,8 @@ export function Activity({
                     hasRenderedCallback={hasRenderedCallback}
                     reportVisibility={reportVisibility}
                     reportVisibilityCallback={reportVisibilityCallback}
-                    renderOnlyItem={renderOnlyItem}
+                    itemAttemptNumbers={itemAttemptNumbers}
+                    itemSequence={itemSequence}
                 />
             );
         }
@@ -110,6 +116,7 @@ export function Activity({
                 <SequenceActivity
                     flags={flags}
                     baseId={baseId}
+                    maxAttemptsAllowed={maxAttemptsAllowed}
                     forceDisable={forceDisable}
                     forceShowCorrectness={forceShowCorrectness}
                     forceShowSolution={forceShowSolution}
@@ -127,7 +134,8 @@ export function Activity({
                     hasRenderedCallback={hasRenderedCallback}
                     reportVisibility={reportVisibility}
                     reportVisibilityCallback={reportVisibilityCallback}
-                    renderOnlyItem={renderOnlyItem}
+                    itemAttemptNumbers={itemAttemptNumbers}
+                    itemSequence={itemSequence}
                 />
             );
         }

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -2,11 +2,12 @@ import { ReactElement } from "react";
 import type { DoenetMLFlags } from "../types";
 import { SelectState } from "./selectState";
 import { Activity } from "./Activity";
-import { ActivityState, getNumItems } from "./activityState";
+import { ActivityState } from "./activityState";
 
 export function SelectActivity({
     flags,
     baseId,
+    maxAttemptsAllowed,
     forceDisable = false,
     forceShowCorrectness = false,
     forceShowSolution = false,
@@ -24,10 +25,12 @@ export function SelectActivity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
-    renderOnlyItem = null,
+    itemAttemptNumbers,
+    itemSequence,
 }: {
     flags: DoenetMLFlags;
     baseId: string;
+    maxAttemptsAllowed: number;
     forceDisable?: boolean;
     forceShowCorrectness?: boolean;
     forceShowSolution?: boolean;
@@ -48,12 +51,11 @@ export function SelectActivity({
     hasRenderedCallback: (id: string) => void;
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
-    renderOnlyItem?: number | null;
+    itemAttemptNumbers: number[];
+    itemSequence: string[];
 }) {
     const selectedActivities: ReactElement[] = [];
     const selectedIds: string[] = [];
-
-    let nextRenderOnly = renderOnlyItem;
 
     for (const activity of state.selectedChildren) {
         selectedActivities.push(
@@ -63,6 +65,7 @@ export function SelectActivity({
                 doenetStates={doenetStates}
                 flags={flags}
                 baseId={baseId}
+                maxAttemptsAllowed={maxAttemptsAllowed}
                 forceDisable={forceDisable}
                 forceShowCorrectness={forceShowCorrectness}
                 forceShowSolution={forceShowSolution}
@@ -78,15 +81,11 @@ export function SelectActivity({
                 hasRenderedCallback={hasRenderedCallback}
                 reportVisibility={reportVisibility}
                 reportVisibilityCallback={reportVisibilityCallback}
-                renderOnlyItem={nextRenderOnly}
+                itemAttemptNumbers={itemAttemptNumbers}
+                itemSequence={itemSequence}
             />,
         );
         selectedIds.push(activity.id);
-
-        if (nextRenderOnly !== null) {
-            // if `numToSelect` is larger than one, account for the items of previous selection(s)
-            nextRenderOnly -= getNumItems(activity.source);
-        }
     }
 
     return (

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -2,11 +2,12 @@ import { ReactElement } from "react";
 import type { DoenetMLFlags } from "../types";
 import { Activity } from "./Activity";
 import { SequenceState } from "./sequenceState";
-import { ActivityState, getNumItems } from "./activityState";
+import { ActivityState } from "./activityState";
 
 export function SequenceActivity({
     flags,
     baseId,
+    maxAttemptsAllowed,
     forceDisable = false,
     forceShowCorrectness = false,
     forceShowSolution = false,
@@ -24,10 +25,12 @@ export function SequenceActivity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
-    renderOnlyItem = null,
+    itemAttemptNumbers,
+    itemSequence,
 }: {
     flags: DoenetMLFlags;
     baseId: string;
+    maxAttemptsAllowed: number;
     forceDisable?: boolean;
     forceShowCorrectness?: boolean;
     forceShowSolution?: boolean;
@@ -48,11 +51,10 @@ export function SequenceActivity({
     hasRenderedCallback: (id: string) => void;
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
-    renderOnlyItem?: number | null;
+    itemAttemptNumbers: number[];
+    itemSequence: string[];
 }) {
     const activityList: ReactElement[] = [];
-
-    let nextRenderOnly = renderOnlyItem;
 
     for (const activity of state.orderedChildren) {
         activityList.push(
@@ -62,6 +64,7 @@ export function SequenceActivity({
                 doenetStates={doenetStates}
                 flags={flags}
                 baseId={baseId}
+                maxAttemptsAllowed={maxAttemptsAllowed}
                 forceDisable={forceDisable}
                 forceShowCorrectness={forceShowCorrectness}
                 forceShowSolution={forceShowSolution}
@@ -77,14 +80,10 @@ export function SequenceActivity({
                 hasRenderedCallback={hasRenderedCallback}
                 reportVisibility={reportVisibility}
                 reportVisibilityCallback={reportVisibilityCallback}
-                renderOnlyItem={nextRenderOnly}
+                itemAttemptNumbers={itemAttemptNumbers}
+                itemSequence={itemSequence}
             />,
         );
-
-        if (nextRenderOnly !== null) {
-            // if more than one item in sequence, account for the items of previous items(s)
-            nextRenderOnly -= getNumItems(activity.source);
-        }
     }
 
     return (

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -58,6 +58,7 @@ export type ActivityState = SingleDocState | SelectState | SequenceState;
 export type ActivityAndDoenetState = {
     activityState: ActivityState;
     doenetStates: unknown[];
+    itemAttemptNumbers: number[];
 };
 
 /**
@@ -80,6 +81,7 @@ export type ActivityStateNoSource =
 export type ExportedActivityState = {
     activityState: ActivityStateNoSource;
     doenetStates: unknown[];
+    itemAttemptNumbers: number[];
     sourceHash: string;
 };
 
@@ -104,7 +106,9 @@ export function isActivityAndDoenetState(
         typedObj !== null &&
         typeof typedObj === "object" &&
         isActivityState(typedObj.activityState) &&
-        Array.isArray(typedObj.doenetStates)
+        Array.isArray(typedObj.doenetStates) &&
+        Array.isArray(typedObj.itemAttemptNumbers) &&
+        typedObj.itemAttemptNumbers.every((x) => Number.isInteger(x) && x > 0)
     );
 }
 
@@ -127,6 +131,10 @@ export function isExportedActivityState(
         typeof typedObj === "object" &&
         isActivityStateNoSource(typedObj.activityState) &&
         Array.isArray(typedObj.doenetStates) &&
+        Array.isArray(typedObj.itemAttemptNumbers) &&
+        typedObj.itemAttemptNumbers.every(
+            (x) => Number.isInteger(x) && x > 0,
+        ) &&
         typeof typedObj.sourceHash === "string"
     );
 }
@@ -206,7 +214,9 @@ export function initializeActivityAndDoenetState({
         restrictToVariantSlice,
     });
 
-    return { activityState, doenetStates: [] };
+    const numItems = getNumItems(source);
+    const itemAttemptNumbers = Array<number>(numItems).fill(1);
+    return { activityState, doenetStates: [], itemAttemptNumbers };
 }
 
 /**

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -33,9 +33,8 @@ export function ActivityViewer({
     flags: specifiedFlags = {},
     activityId = "a",
     userId = null,
-    attemptNumber = 1,
     requestedVariantIndex,
-    maxAttemptsAllowed = Infinity,
+    maxAttemptsAllowed = 1,
     itemLevelAttempts = false,
     activityLevelAttempts = false,
     paginate = true,
@@ -51,13 +50,11 @@ export function ActivityViewer({
     showAnswerTitles = false,
     includeVariantSelector: _includeVariantSelector = false,
     showTitle = true,
-    renderOnlyItem = null,
 }: {
     source: ActivitySource;
     flags?: DoenetMLFlagsSubset;
     activityId?: string;
     userId?: string | null;
-    attemptNumber?: number;
     requestedVariantIndex?: number;
     maxAttemptsAllowed?: number;
     itemLevelAttempts?: boolean;
@@ -75,7 +72,6 @@ export function ActivityViewer({
     showAnswerTitles?: boolean;
     includeVariantSelector?: boolean;
     showTitle?: boolean;
-    renderOnlyItem?: number | null;
 }) {
     // const [variants, setVariants] = useState({
     //     index: 1,
@@ -131,7 +127,6 @@ export function ActivityViewer({
                 flags={flags}
                 activityId={activityId}
                 userId={userId}
-                attemptNumber={attemptNumber}
                 variantIndex={variantIndex}
                 maxAttemptsAllowed={maxAttemptsAllowed}
                 itemLevelAttempts={itemLevelAttempts}
@@ -150,7 +145,6 @@ export function ActivityViewer({
                 darkMode={darkMode}
                 showAnswerTitles={showAnswerTitles}
                 showTitle={showTitle}
-                renderOnlyItem={renderOnlyItem}
             />
         </ErrorBoundary>
     );

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -33,7 +33,11 @@ describe("Activity reducer tests", () => {
         const { numActivityVariants } = gatherDocumentStructure(source);
 
         const newState = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            {
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers: [1],
+            },
             {
                 type: "initialize",
                 source,
@@ -60,6 +64,7 @@ describe("Activity reducer tests", () => {
         expect(newState).eqls({
             activityState: expectedActivityState,
             doenetStates: [],
+            itemAttemptNumbers: [1],
         });
     });
 
@@ -87,10 +92,18 @@ describe("Activity reducer tests", () => {
             numActivityVariants,
         });
 
-        const state = { activityState, doenetStates: [] };
+        const state = {
+            activityState,
+            doenetStates: [],
+            itemAttemptNumbers: [1],
+        };
 
         let newState = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            {
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers: [1],
+            },
             {
                 type: "set",
                 state,
@@ -103,7 +116,7 @@ describe("Activity reducer tests", () => {
         expect(spy).toHaveBeenCalledTimes(0);
 
         newState = activityDoenetStateReducer(
-            { activityState, doenetStates: [] },
+            { activityState, doenetStates: [], itemAttemptNumbers: [1] },
             {
                 type: "set",
                 state,
@@ -153,7 +166,11 @@ describe("Activity reducer tests", () => {
         state0.creditAchieved = 0.8;
 
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            {
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers: [1],
+            },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -171,7 +188,7 @@ describe("Activity reducer tests", () => {
         expect(typeof activityState.currentVariant).eq("number");
         const previousVariants = [activityState.currentVariant];
 
-        let expectState: SingleDocState = {
+        let expectedState: SingleDocState = {
             ...state0,
             initialQuestionCounter: 9,
             creditAchieved: 0,
@@ -180,11 +197,15 @@ describe("Activity reducer tests", () => {
             previousVariants,
         };
 
-        expect(activityState).eqls(expectState);
+        expect(activityState).eqls(expectedState);
 
         // repeat creation of first attempt, this time with `allowSaveState`
         state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            {
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers: [1],
+            },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -197,7 +218,7 @@ describe("Activity reducer tests", () => {
         );
         activityState = state.activityState as SingleDocState;
 
-        expect(activityState).eqls(expectState);
+        expect(activityState).eqls(expectedState);
 
         expect(spy).toHaveBeenCalledTimes(1);
 
@@ -231,7 +252,7 @@ describe("Activity reducer tests", () => {
         expect(typeof activityState.currentVariant).eq("number");
         previousVariants.push(activityState.currentVariant);
 
-        expectState = {
+        expectedState = {
             ...state0,
             initialQuestionCounter: 6,
             creditAchieved: 0,
@@ -258,6 +279,7 @@ describe("Activity reducer tests", () => {
                     activityState: pruneActivityStateForSave(activityState),
                     sourceHash,
                     doenetStates: [],
+                    itemAttemptNumbers: [1],
                 },
                 activityId: "newId",
                 newAttempt: true,
@@ -286,7 +308,11 @@ describe("Activity reducer tests", () => {
         });
 
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            {
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers: [1],
+            },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -342,6 +368,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 1"],
+                    itemAttemptNumbers: [1],
                     sourceHash,
                 },
                 newDoenetStateIdx: 0,
@@ -398,6 +425,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 2"],
+                    itemAttemptNumbers: [1],
                     sourceHash,
                 },
                 newDoenetStateIdx: 0,
@@ -454,6 +482,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 3"],
+                    itemAttemptNumbers: [1],
                     sourceHash,
                 },
                 newDoenetStateIdx: 0,
@@ -503,6 +532,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: [],
+                    itemAttemptNumbers: [1],
                     sourceHash,
                 },
                 activityId: "newId",
@@ -542,7 +572,7 @@ describe("Activity reducer tests", () => {
 
         expect(spy).toHaveBeenCalledTimes(5);
 
-        expect(spy.mock.lastCall).toMatchObject([
+        expect(spy.mock.lastCall).eqls([
             {
                 subject: "SPLICE.reportScoreAndState",
                 score: 0.1,
@@ -557,6 +587,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 4"],
+                    itemAttemptNumbers: [1],
                     sourceHash,
                 },
                 newDoenetStateIdx: 0,
@@ -598,7 +629,7 @@ describe("Activity reducer tests", () => {
 
         expect(spy).toHaveBeenCalledTimes(6);
 
-        expect(spy.mock.lastCall).toMatchObject([
+        expect(spy.mock.lastCall).eqls([
             {
                 subject: "SPLICE.reportScoreAndState",
                 score: 0.5,
@@ -613,6 +644,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 5"],
+                    itemAttemptNumbers: [1],
                     sourceHash,
                 },
                 newDoenetStateIdx: 0,
@@ -633,6 +665,7 @@ describe("Activity reducer tests", () => {
         docStates,
         docIds,
         attemptNumber,
+        itemAttemptNumbers,
         newAttempt,
         newAttemptForItem,
         newDoenetStateIdx,
@@ -645,6 +678,7 @@ describe("Activity reducer tests", () => {
         docStates: (string | undefined)[];
         docIds: string[];
         attemptNumber: number;
+        itemAttemptNumbers: number[];
         newAttempt?: boolean;
         newAttemptForItem?: number;
         newDoenetStateIdx?: number;
@@ -716,6 +750,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: docStates,
+                    itemAttemptNumbers,
                     sourceHash,
                 },
                 activityId: "newId",
@@ -751,8 +786,14 @@ describe("Activity reducer tests", () => {
             numActivityVariants,
         });
 
+        const itemAttemptNumbers = [1, 1, 1];
+
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            {
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers,
+            },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -798,6 +839,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -823,6 +865,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             sourceHash,
             newDoenetStateIdx: 1,
             spy,
@@ -849,6 +892,7 @@ describe("Activity reducer tests", () => {
             docIds,
             newDoenetStateIdx: 1,
             attemptNumber,
+            itemAttemptNumbers,
             sourceHash,
             spy,
         });
@@ -876,6 +920,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             sourceHash,
             spy,
@@ -902,6 +947,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 2,
             sourceHash,
             spy,
@@ -928,8 +974,10 @@ describe("Activity reducer tests", () => {
             numActivityVariants,
         });
 
+        const itemAttemptNumbers = [1, 1, 1];
+
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            { activityState: state0, doenetStates: [], itemAttemptNumbers },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -975,6 +1023,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1000,6 +1049,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1025,6 +1075,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1035,6 +1086,7 @@ describe("Activity reducer tests", () => {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             questionCounts: {},
@@ -1044,6 +1096,7 @@ describe("Activity reducer tests", () => {
         });
 
         docAttemptNumbers[0]++;
+        itemAttemptNumbers[0]++;
         docCredits[0] = 0;
         docStates[0] = undefined;
 
@@ -1054,6 +1107,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             newAttemptForItem: childIds.indexOf(docIds[0]) + 1,
             newDoenetStateIdx: 0,
@@ -1082,6 +1136,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1108,6 +1163,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 2,
             sourceHash,
             spy,
@@ -1134,6 +1190,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1144,6 +1201,7 @@ describe("Activity reducer tests", () => {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             questionCounts: {},
@@ -1153,6 +1211,7 @@ describe("Activity reducer tests", () => {
         });
 
         docAttemptNumbers[1]++;
+        itemAttemptNumbers[1]++;
         docCredits[1] = 0;
         docStates[1] = undefined;
 
@@ -1163,6 +1222,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             newAttemptForItem: childIds.indexOf(docIds[1]) + 1,
             newDoenetStateIdx: 1,
@@ -1191,6 +1251,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1207,6 +1268,7 @@ describe("Activity reducer tests", () => {
         docStates,
         docIds,
         attemptNumber,
+        itemAttemptNumbers,
         newAttempt,
         newAttemptForItem,
         newDoenetStateIdx,
@@ -1222,6 +1284,7 @@ describe("Activity reducer tests", () => {
         docStates: (string | undefined)[];
         docIds: string[];
         attemptNumber: number;
+        itemAttemptNumbers: number[];
         newAttempt?: boolean;
         newAttemptForItem?: number;
         newDoenetStateIdx?: number;
@@ -1285,7 +1348,7 @@ describe("Activity reducer tests", () => {
             newInfoObj.newDoenetStateIdx = newDoenetStateIdx;
         }
 
-        expect(spy.mock.lastCall).toMatchObject([
+        expect(spy.mock.lastCall).eqls([
             {
                 subject: "SPLICE.reportScoreAndState",
                 score: creditAchieved,
@@ -1301,6 +1364,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: docStates,
+                    itemAttemptNumbers,
                     sourceHash,
                 },
                 activityId: "newId",
@@ -1336,8 +1400,9 @@ describe("Activity reducer tests", () => {
             numActivityVariants,
         });
 
+        const itemAttemptNumbers = [1, 1];
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            { activityState: state0, doenetStates: [], itemAttemptNumbers },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -1398,6 +1463,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1428,6 +1494,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1458,6 +1525,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1511,6 +1579,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             spy,
             sourceHash,
@@ -1540,6 +1609,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1566,8 +1636,10 @@ describe("Activity reducer tests", () => {
             numActivityVariants,
         });
 
+        const itemAttemptNumbers = [1, 1];
+
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            { activityState: state0, doenetStates: [], itemAttemptNumbers },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -1628,6 +1700,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1658,6 +1731,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1688,6 +1762,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1698,6 +1773,7 @@ describe("Activity reducer tests", () => {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             questionCounts: {},
@@ -1724,6 +1800,7 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0; // don't change selCredit[1], as the credit achieved is remembered
         docStates[1] = undefined;
         docCredits[1] = 0;
+        itemAttemptNumbers[1]++;
 
         testStateSeq2Sels({
             state,
@@ -1735,6 +1812,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             newAttemptForItem: childIds.indexOf(selIds[1]) + 1,
             newDoenetStateIdx: 1,
@@ -1767,6 +1845,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1797,6 +1876,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1807,6 +1887,7 @@ describe("Activity reducer tests", () => {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             questionCounts: {},
@@ -1833,6 +1914,7 @@ describe("Activity reducer tests", () => {
         selCredits[0] = 0; // don't change selCredit[0], as the credit achieved is remembered
         docStates[0] = undefined;
         docCredits[0] = 0;
+        itemAttemptNumbers[0]++;
 
         testStateSeq2Sels({
             state,
@@ -1844,6 +1926,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             newAttemptForItem: childIds.indexOf(selIds[0]) + 1,
             newDoenetStateIdx: 0,
@@ -1876,6 +1959,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1889,6 +1973,7 @@ describe("Activity reducer tests", () => {
         docStates,
         docIds,
         attemptNumber,
+        itemAttemptNumbers,
         newAttempt,
         newAttemptForItem,
         newDoenetStateIdx,
@@ -1901,6 +1986,7 @@ describe("Activity reducer tests", () => {
         docStates: (string | undefined)[];
         docIds: string[];
         attemptNumber: number;
+        itemAttemptNumbers: number[];
         newAttempt?: boolean;
         newAttemptForItem?: number;
         newDoenetStateIdx?: number;
@@ -1956,7 +2042,7 @@ describe("Activity reducer tests", () => {
             newInfoObj.newDoenetStateIdx = newDoenetStateIdx;
         }
 
-        expect(spy.mock.lastCall).toMatchObject([
+        expect(spy.mock.lastCall).eqls([
             {
                 subject: "SPLICE.reportScoreAndState",
                 score: creditAchieved,
@@ -1977,6 +2063,7 @@ describe("Activity reducer tests", () => {
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: docStates,
+                    itemAttemptNumbers,
                     sourceHash,
                 },
                 activityId: "newId",
@@ -2012,8 +2099,10 @@ describe("Activity reducer tests", () => {
             numActivityVariants,
         });
 
+        const itemAttemptNumbers = [1, 1];
+
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [] },
+            { activityState: state0, doenetStates: [], itemAttemptNumbers },
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -2060,6 +2149,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -2086,6 +2176,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2112,6 +2203,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2122,6 +2214,7 @@ describe("Activity reducer tests", () => {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             questionCounts: {},
@@ -2143,6 +2236,8 @@ describe("Activity reducer tests", () => {
         docStates[1] = undefined;
         docCredits[1] = 0;
 
+        itemAttemptNumbers[1]++;
+
         testStateSelMult2Docs({
             state,
             docCredits,
@@ -2150,6 +2245,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             newAttemptForItem: 2,
             newDoenetStateIdx: 1,
@@ -2178,6 +2274,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2204,6 +2301,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2214,6 +2312,7 @@ describe("Activity reducer tests", () => {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             questionCounts: {},
@@ -2234,6 +2333,7 @@ describe("Activity reducer tests", () => {
 
         docStates[0] = undefined;
         docCredits[0] = 0;
+        itemAttemptNumbers[0]++;
 
         testStateSelMult2Docs({
             state,
@@ -2242,6 +2342,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newAttempt: true,
             newAttemptForItem: 1,
             newDoenetStateIdx: 0,
@@ -2270,6 +2371,7 @@ describe("Activity reducer tests", () => {
             docStates,
             docIds,
             attemptNumber,
+            itemAttemptNumbers,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,


### PR DESCRIPTION
This PR add the ability to track both activity-wide and item-level attempts. The new attempt buttons are visible only if the maximum number of attempts allowed is not 1. If this limit is finite (i.e., not 0, which indicates unlimited), the the new attempt buttons indicate the number of attempts left and become disabled when that limit is reached.

This PR also removes the feature from #10 to render just a single item, given that with #13, single doc states are separated and can be easily rendered alone from that state.