### PR TITLE
Add itemUpdated to reportScoreAndState messages

### DIFF
--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -121,6 +121,7 @@ export function isActivityStateNoSource(
         isSequenceStateNoSource(obj)
     );
 }
+
 export function isExportedActivityState(
     obj: unknown,
 ): obj is ExportedActivityState {
@@ -406,7 +407,7 @@ export function extractActivityItemCredit(
     nPrevInShuffleOrder = 0,
 ): {
     id: string;
-    docId?: string;
+    docId: string;
     score: number;
     shuffledOrder: number;
 }[] {

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -56,9 +56,10 @@ type GenerateSingleDocSubAttemptAction = {
 
 type UpdateSingleDocStateAction = {
     type: "updateSingleState";
-    id: string;
+    docId: string;
     doenetState: unknown;
     doenetStateIdx: number;
+    itemSequence: string[];
     creditAchieved: number;
     allowSaveState: boolean;
     baseId: string;
@@ -266,8 +267,8 @@ function updateSingleDocState(
 ): ActivityAndDoenetState {
     const allStates = gatherStates(activityDoenetState.activityState);
 
-    const newSingleDocState = (allStates[action.id] = {
-        ...allStates[action.id],
+    const newSingleDocState = (allStates[action.docId] = {
+        ...allStates[action.docId],
     });
 
     if (newSingleDocState.type !== "singleDoc") {

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -174,7 +174,7 @@ export function activityDoenetStateReducer(
             });
 
             const newDoenetMLStates = [...state.doenetStates];
-            newDoenetMLStates[action.doenetStateIdx] = undefined;
+            newDoenetMLStates[action.doenetStateIdx] = null;
 
             // increment the item attempt number corresponding to the document
             const itemIdx = action.itemSequence.indexOf(action.docId);
@@ -226,6 +226,9 @@ export function activityDoenetStateReducer(
                 const newActivityState = newActivityDoenetState.activityState;
                 const itemScores = extractActivityItemCredit(newActivityState);
 
+                const itemUpdated =
+                    action.itemSequence.indexOf(action.docId) + 1;
+
                 const message: ReportStateMessage = {
                     state: {
                         activityState:
@@ -236,6 +239,7 @@ export function activityDoenetStateReducer(
                     },
                     score: newActivityState.creditAchieved,
                     itemScores,
+                    itemUpdated,
                     newDoenetStateIdx: action.doenetStateIdx,
                     subject: "SPLICE.reportScoreAndState",
                     activityId: action.baseId,

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -622,17 +622,30 @@ export function extractSelectItemCredit(
 ): {
     id: string;
     score: number;
-    docId?: string;
+    docId: string;
     shuffledOrder: number;
 }[] {
     if (activityState.attemptNumber === 0) {
-        return [
-            {
-                id: activityState.id,
-                score: 0,
-                shuffledOrder: nPrevInShuffleOrder + 1,
-            },
-        ];
+        const nChildren = activityState.allChildren.length;
+        if (nChildren === 0) {
+            return [];
+        }
+        // just select the items in order to give results that are at least in the right form
+        const results: {
+            id: string;
+            score: number;
+            docId: string;
+            shuffledOrder: number;
+        }[] = [];
+        let nPrev = nPrevInShuffleOrder;
+
+        for (let i = 0; i < activityState.source.numToSelect; i++) {
+            const childState = activityState.allChildren[i % nChildren];
+            const next = extractActivityItemCredit(childState, nPrev);
+            nPrev += next.length;
+            results.push(...next);
+        }
+        return results;
     }
     if (
         activityState.source.numToSelect === 1 &&

--- a/src/Activity/sequenceState.ts
+++ b/src/Activity/sequenceState.ts
@@ -341,17 +341,17 @@ export function extractSequenceItemCredit(
 ): {
     id: string;
     score: number;
-    docId?: string;
+    docId: string;
     shuffledOrder: number;
 }[] {
     if (activityState.attemptNumber === 0) {
-        return [
-            {
-                id: activityState.id,
-                score: 0,
-                shuffledOrder: nPrevInShuffleOrder + 1,
-            },
-        ];
+        // just select the items in original order to give results that are at least in the right form
+        let nPrev = nPrevInShuffleOrder;
+        return activityState.allChildren.flatMap((state) => {
+            const next = extractActivityItemCredit(state, nPrev);
+            nPrev += next.length;
+            return next;
+        });
     } else {
         let nPrev = nPrevInShuffleOrder;
         const inShuffledOrder = activityState.orderedChildren.map((state) => {

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -336,9 +336,10 @@ export function Viewer({
         if (isSingleDocReportStateMessage(msg)) {
             activityDoenetStateDispatch({
                 type: "updateSingleState",
-                id: msg.docId,
+                docId: msg.docId,
                 doenetState: msg.state,
                 doenetStateIdx: itemSequence.indexOf(msg.docId),
+                itemSequence,
                 creditAchieved: msg.score,
                 allowSaveState: flags.allowSaveState,
                 baseId: activityId,

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -327,9 +327,10 @@ describe("Activity reducer tests", () => {
         // Get score of 0.2
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: "doc5",
+            docId: "doc5",
             doenetStateIdx: 0,
             doenetState: "DoenetML state 1",
+            itemSequence: ["doc5"],
             creditAchieved: 0.2,
             allowSaveState: true,
             baseId: "newId",
@@ -365,6 +366,7 @@ describe("Activity reducer tests", () => {
                         shuffledOrder: 1,
                     },
                 ],
+                itemUpdated: 1,
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 1"],
@@ -384,9 +386,10 @@ describe("Activity reducer tests", () => {
         // decrease score
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: "doc5",
+            docId: "doc5",
             doenetState: "DoenetML state 2",
             doenetStateIdx: 0,
+            itemSequence: ["doc5"],
             creditAchieved: 0.1,
             allowSaveState: true,
             baseId: "newId",
@@ -422,6 +425,7 @@ describe("Activity reducer tests", () => {
                         shuffledOrder: 1,
                     },
                 ],
+                itemUpdated: 1,
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 2"],
@@ -441,9 +445,10 @@ describe("Activity reducer tests", () => {
         // increase score
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: "doc5",
+            docId: "doc5",
             doenetState: "DoenetML state 3",
             doenetStateIdx: 0,
+            itemSequence: ["doc5"],
             creditAchieved: 0.3,
             allowSaveState: true,
             baseId: "newId",
@@ -479,6 +484,7 @@ describe("Activity reducer tests", () => {
                         shuffledOrder: 1,
                     },
                 ],
+                itemUpdated: 1,
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 3"],
@@ -546,9 +552,10 @@ describe("Activity reducer tests", () => {
         // start attempt with low score
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: "doc5",
+            docId: "doc5",
             doenetState: "DoenetML state 4",
             doenetStateIdx: 0,
+            itemSequence: ["doc5"],
             creditAchieved: 0.1,
             allowSaveState: true,
             baseId: "newId",
@@ -584,6 +591,7 @@ describe("Activity reducer tests", () => {
                         shuffledOrder: 1,
                     },
                 ],
+                itemUpdated: 1,
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 4"],
@@ -603,9 +611,10 @@ describe("Activity reducer tests", () => {
         // increase score
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: "doc5",
+            docId: "doc5",
             doenetState: "DoenetML state 5",
             doenetStateIdx: 0,
+            itemSequence: ["doc5"],
             creditAchieved: 0.5,
             allowSaveState: true,
             baseId: "newId",
@@ -641,6 +650,7 @@ describe("Activity reducer tests", () => {
                         shuffledOrder: 1,
                     },
                 ],
+                itemUpdated: 1,
                 state: {
                     activityState: pruneActivityStateForSave(activityState),
                     doenetStates: ["DoenetML state 5"],
@@ -666,6 +676,7 @@ describe("Activity reducer tests", () => {
         docIds,
         attemptNumber,
         itemAttemptNumbers,
+        itemUpdated,
         newAttempt,
         newAttemptForItem,
         newDoenetStateIdx,
@@ -675,10 +686,11 @@ describe("Activity reducer tests", () => {
         state: ActivityAndDoenetState;
         docCredits: number[];
         docAttemptNumbers: number[];
-        docStates: (string | undefined)[];
+        docStates: (string | undefined | null)[];
         docIds: string[];
         attemptNumber: number;
         itemAttemptNumbers: number[];
+        itemUpdated?: number;
         newAttempt?: boolean;
         newAttemptForItem?: number;
         newDoenetStateIdx?: number;
@@ -707,7 +719,7 @@ describe("Activity reducer tests", () => {
             expect(docState.id).eq(docIds[i]);
             expect(docState.creditAchieved).eq(docCredits[i]);
             expect(docState.attemptNumber).eq(docAttemptNumbers[i]);
-            if (docStates[i] === undefined) {
+            if (docStates[i] === undefined || docStates[i] === null) {
                 expect(docState.doenetStateIdx === null);
             } else {
                 if (docState.doenetStateIdx === null) {
@@ -723,6 +735,7 @@ describe("Activity reducer tests", () => {
             newAttempt?: boolean;
             newAttemptForItem?: number;
             newDoenetStateIdx?: number;
+            itemUpdated?: number;
         } = {};
         if (newAttempt) {
             newInfoObj.newAttempt = true;
@@ -732,6 +745,9 @@ describe("Activity reducer tests", () => {
         }
         if (newDoenetStateIdx !== undefined) {
             newInfoObj.newDoenetStateIdx = newDoenetStateIdx;
+        }
+        if (itemUpdated !== undefined) {
+            newInfoObj.itemUpdated = itemUpdated;
         }
 
         expect(spy.mock.lastCall).eqls([
@@ -815,7 +831,7 @@ describe("Activity reducer tests", () => {
         const docIds = activityState.orderedChildren.map((c) => c.id);
         let docCredits = [0, 0, 0];
         let docAttemptNumbers = [1, 1, 1];
-        let docStates: (string | undefined)[] = [];
+        let docStates: (string | undefined | null)[] = [];
         let attemptNumber = 1;
 
         // Get score of 0.4 in first doc
@@ -823,9 +839,10 @@ describe("Activity reducer tests", () => {
         docCredits[0] = 0.4;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -840,6 +857,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -850,9 +868,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.6;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -866,6 +885,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             sourceHash,
             newDoenetStateIdx: 1,
             spy,
@@ -876,9 +896,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -893,6 +914,7 @@ describe("Activity reducer tests", () => {
             newDoenetStateIdx: 1,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             sourceHash,
             spy,
         });
@@ -931,9 +953,10 @@ describe("Activity reducer tests", () => {
         docCredits[2] = 0.8;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[2],
+            docId: docIds[2],
             doenetState: docStates[2],
             doenetStateIdx: 2,
+            itemSequence: docIds,
             creditAchieved: docCredits[2],
             allowSaveState: true,
             baseId: "newId",
@@ -948,6 +971,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 3,
             newDoenetStateIdx: 2,
             sourceHash,
             spy,
@@ -999,7 +1023,7 @@ describe("Activity reducer tests", () => {
         const docIds = activityState.orderedChildren.map((c) => c.id);
         const docCredits = [0, 0, 0];
         const docAttemptNumbers = [1, 1, 1];
-        const docStates: (string | undefined)[] = [];
+        const docStates: (string | undefined | null)[] = [];
         const attemptNumber = 1;
 
         // Get score of 0.4 in first doc
@@ -1007,9 +1031,10 @@ describe("Activity reducer tests", () => {
         docCredits[0] = 0.4;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1024,6 +1049,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1034,9 +1060,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.6;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1050,6 +1077,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1060,9 +1088,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1076,6 +1105,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1098,7 +1128,7 @@ describe("Activity reducer tests", () => {
         docAttemptNumbers[0]++;
         itemAttemptNumbers[0]++;
         docCredits[0] = 0;
-        docStates[0] = undefined;
+        docStates[0] = null;
 
         testStateSeq3Docs({
             state,
@@ -1120,9 +1150,10 @@ describe("Activity reducer tests", () => {
         docCredits[0] = 0.5;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1137,6 +1168,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1147,9 +1179,10 @@ describe("Activity reducer tests", () => {
         docCredits[2] = 0.8;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[2],
+            docId: docIds[2],
             doenetState: docStates[2],
             doenetStateIdx: 2,
+            itemSequence: docIds,
             creditAchieved: docCredits[2],
             allowSaveState: true,
             baseId: "newId",
@@ -1164,6 +1197,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 3,
             newDoenetStateIdx: 2,
             sourceHash,
             spy,
@@ -1174,9 +1208,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1191,6 +1226,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1213,7 +1249,7 @@ describe("Activity reducer tests", () => {
         docAttemptNumbers[1]++;
         itemAttemptNumbers[1]++;
         docCredits[1] = 0;
-        docStates[1] = undefined;
+        docStates[1] = null;
 
         testStateSeq3Docs({
             state,
@@ -1235,9 +1271,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.9;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1252,6 +1289,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1269,6 +1307,7 @@ describe("Activity reducer tests", () => {
         docIds,
         attemptNumber,
         itemAttemptNumbers,
+        itemUpdated,
         newAttempt,
         newAttemptForItem,
         newDoenetStateIdx,
@@ -1281,10 +1320,11 @@ describe("Activity reducer tests", () => {
         selIds: string[];
         docCredits: number[];
         docAttemptNumbers: Record<string, number>;
-        docStates: (string | undefined)[];
+        docStates: (string | undefined | null)[];
         docIds: string[];
         attemptNumber: number;
         itemAttemptNumbers: number[];
+        itemUpdated?: number;
         newAttempt?: boolean;
         newAttemptForItem?: number;
         newDoenetStateIdx?: number;
@@ -1321,7 +1361,7 @@ describe("Activity reducer tests", () => {
             expect(docState.id).eq(docIds[i]);
             expect(docState.creditAchieved).eq(docCredits[i]);
             expect(docState.attemptNumber).eq(docAttemptNumbers[docIds[i]]);
-            if (docStates[i] === undefined) {
+            if (docStates[i] === undefined || docStates[i] === null) {
                 expect(docState.doenetStateIdx === null);
             } else {
                 if (docState.doenetStateIdx === null) {
@@ -1337,6 +1377,7 @@ describe("Activity reducer tests", () => {
             newAttempt?: boolean;
             newAttemptForItem?: number;
             newDoenetStateIdx?: number;
+            itemUpdated?: number;
         } = {};
         if (newAttempt) {
             newInfoObj.newAttempt = true;
@@ -1346,6 +1387,9 @@ describe("Activity reducer tests", () => {
         }
         if (newDoenetStateIdx !== undefined) {
             newInfoObj.newDoenetStateIdx = newDoenetStateIdx;
+        }
+        if (itemUpdated !== undefined) {
+            newInfoObj.itemUpdated = itemUpdated;
         }
 
         expect(spy.mock.lastCall).eqls([
@@ -1435,7 +1479,7 @@ describe("Activity reducer tests", () => {
 
         const docAttemptNumbers = { [docIds[0]]: 1, [docIds[1]]: 1 };
         let docCredits = [0, 0];
-        let docStates: (string | undefined)[] = [];
+        let docStates: (string | undefined | null)[] = [];
         let attemptNumber = 1;
 
         // Get score of 0.4 in first doc
@@ -1444,9 +1488,10 @@ describe("Activity reducer tests", () => {
         selCredits[0] = 0.4;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1464,6 +1509,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1475,9 +1521,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.6;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1495,6 +1542,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1506,9 +1554,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1526,6 +1575,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1591,9 +1641,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.8;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1610,6 +1661,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1672,7 +1724,7 @@ describe("Activity reducer tests", () => {
 
         const docAttemptNumbers = { [docIds[0]]: 1, [docIds[1]]: 1 };
         const docCredits = [0, 0];
-        const docStates: (string | undefined)[] = [];
+        const docStates: (string | undefined | null)[] = [];
         const attemptNumber = 1;
 
         // Get score of 0.4 in first doc
@@ -1681,9 +1733,10 @@ describe("Activity reducer tests", () => {
         selCredits[0] = 0.4;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1701,6 +1754,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1712,9 +1766,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.6;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1732,6 +1787,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1743,9 +1799,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1763,6 +1820,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1798,7 +1856,7 @@ describe("Activity reducer tests", () => {
 
         selAttemptNumbers[1]++;
         selCredits[1] = 0; // don't change selCredit[1], as the credit achieved is remembered
-        docStates[1] = undefined;
+        docStates[1] = null;
         docCredits[1] = 0;
         itemAttemptNumbers[1]++;
 
@@ -1826,9 +1884,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.8;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1846,6 +1905,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1857,9 +1917,10 @@ describe("Activity reducer tests", () => {
         selCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1877,6 +1938,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -1912,7 +1974,7 @@ describe("Activity reducer tests", () => {
 
         selAttemptNumbers[0]++;
         selCredits[0] = 0; // don't change selCredit[0], as the credit achieved is remembered
-        docStates[0] = undefined;
+        docStates[0] = null;
         docCredits[0] = 0;
         itemAttemptNumbers[0]++;
 
@@ -1940,9 +2002,10 @@ describe("Activity reducer tests", () => {
         selCredits[0] = 0.3;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1960,6 +2023,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -1974,6 +2038,7 @@ describe("Activity reducer tests", () => {
         docIds,
         attemptNumber,
         itemAttemptNumbers,
+        itemUpdated,
         newAttempt,
         newAttemptForItem,
         newDoenetStateIdx,
@@ -1983,10 +2048,11 @@ describe("Activity reducer tests", () => {
         state: ActivityAndDoenetState;
         docCredits: number[];
         docAttemptNumbers: Record<string, number>;
-        docStates: (string | undefined)[];
+        docStates: (string | undefined | null)[];
         docIds: string[];
         attemptNumber: number;
         itemAttemptNumbers: number[];
+        itemUpdated?: number;
         newAttempt?: boolean;
         newAttemptForItem?: number;
         newDoenetStateIdx?: number;
@@ -2015,7 +2081,7 @@ describe("Activity reducer tests", () => {
             expect(docState.id).eq(docIds[i]);
             expect(docState.creditAchieved).eq(docCredits[i]);
             expect(docState.attemptNumber).eq(docAttemptNumbers[docIds[i]]);
-            if (docStates[i] === undefined) {
+            if (docStates[i] === undefined || docStates[i] === null) {
                 expect(docState.doenetStateIdx === null);
             } else {
                 if (docState.doenetStateIdx === null) {
@@ -2031,6 +2097,7 @@ describe("Activity reducer tests", () => {
             newAttempt?: boolean;
             newAttemptForItem?: number;
             newDoenetStateIdx?: number;
+            itemUpdated?: number;
         } = {};
         if (newAttempt) {
             newInfoObj.newAttempt = true;
@@ -2040,6 +2107,9 @@ describe("Activity reducer tests", () => {
         }
         if (newDoenetStateIdx !== undefined) {
             newInfoObj.newDoenetStateIdx = newDoenetStateIdx;
+        }
+        if (itemUpdated !== undefined) {
+            newInfoObj.itemUpdated = itemUpdated;
         }
 
         expect(spy.mock.lastCall).eqls([
@@ -2125,7 +2195,7 @@ describe("Activity reducer tests", () => {
 
         const docAttemptNumbers = { [docIds[0]]: 1, [docIds[1]]: 1 };
         const docCredits = [0, 0];
-        const docStates: (string | undefined)[] = [];
+        const docStates: (string | undefined | null)[] = [];
         const attemptNumber = 1;
 
         // Get score of 0.4 in first doc
@@ -2133,9 +2203,10 @@ describe("Activity reducer tests", () => {
         docCredits[0] = 0.4;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -2150,6 +2221,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,
@@ -2160,9 +2232,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.6;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2177,6 +2250,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2187,9 +2261,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2204,6 +2279,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2233,7 +2309,7 @@ describe("Activity reducer tests", () => {
         docIds[1] = activityState.selectedChildren[1].id;
         docAttemptNumbers[docIds[1]] = (docAttemptNumbers[docIds[1]] ?? 0) + 1;
 
-        docStates[1] = undefined;
+        docStates[1] = null;
         docCredits[1] = 0;
 
         itemAttemptNumbers[1]++;
@@ -2258,9 +2334,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.8;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2275,6 +2352,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2285,9 +2363,10 @@ describe("Activity reducer tests", () => {
         docCredits[1] = 0.2;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[1],
+            docId: docIds[1],
             doenetState: docStates[1],
             doenetStateIdx: 1,
+            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2302,6 +2381,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 2,
             newDoenetStateIdx: 1,
             sourceHash,
             spy,
@@ -2331,7 +2411,7 @@ describe("Activity reducer tests", () => {
         docIds[0] = activityState.selectedChildren[0].id;
         docAttemptNumbers[docIds[0]] = (docAttemptNumbers[docIds[0]] ?? 0) + 1;
 
-        docStates[0] = undefined;
+        docStates[0] = null;
         docCredits[0] = 0;
         itemAttemptNumbers[0]++;
 
@@ -2355,9 +2435,10 @@ describe("Activity reducer tests", () => {
         docCredits[0] = 0.3;
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
-            id: docIds[0],
+            docId: docIds[0],
             doenetState: docStates[0],
             doenetStateIdx: 0,
+            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -2372,6 +2453,7 @@ describe("Activity reducer tests", () => {
             docIds,
             attemptNumber,
             itemAttemptNumbers,
+            itemUpdated: 1,
             newDoenetStateIdx: 0,
             sourceHash,
             spy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export type ReportStateMessage = {
         docId?: string;
         shuffledOrder: number;
     }[];
+    itemUpdated?: number;
     state: ExportedActivityState;
     newAttempt?: boolean;
     newAttemptForItem?: number;
@@ -91,31 +92,33 @@ export type ReportStateMessage = {
 };
 
 export function isReportStateMessage(obj: unknown): obj is ReportStateMessage {
-    const typeObj = obj as ReportStateMessage;
+    const typedObj = obj as ReportStateMessage;
 
     return (
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        typeObj !== null &&
-        typeof typeObj === "object" &&
+        typedObj !== null &&
+        typeof typedObj === "object" &&
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        typeObj.subject === "SPLICE.reportScoreAndState" &&
-        typeof typeObj.activityId === "string" &&
-        typeof typeObj.score === "number" &&
-        Array.isArray(typeObj.itemScores) &&
-        typeObj.itemScores.every(
+        typedObj.subject === "SPLICE.reportScoreAndState" &&
+        typeof typedObj.activityId === "string" &&
+        typeof typedObj.score === "number" &&
+        Array.isArray(typedObj.itemScores) &&
+        typedObj.itemScores.every(
             (item) =>
                 typeof item.id === "string" &&
                 typeof item.score === "number" &&
                 (item.docId === undefined || typeof item.docId === "string") &&
                 typeof item.shuffledOrder === "number",
         ) &&
-        isExportedActivityState(typeObj.state) &&
-        (typeObj.newAttempt === undefined ||
-            typeof typeObj.newAttempt === "boolean") &&
-        (typeObj.newAttemptForItem === undefined ||
-            typeof typeObj.newAttemptForItem === "number") &&
-        (typeObj.newDoenetStateIdx === undefined ||
-            typeof typeObj.newDoenetStateIdx === "number")
+        (typedObj.itemUpdated === undefined ||
+            typeof typedObj.itemUpdated === "number") &&
+        isExportedActivityState(typedObj.state) &&
+        (typedObj.newAttempt === undefined ||
+            typeof typedObj.newAttempt === "boolean") &&
+        (typedObj.newAttemptForItem === undefined ||
+            typeof typedObj.newAttemptForItem === "number") &&
+        (typedObj.newDoenetStateIdx === undefined ||
+            typeof typedObj.newDoenetStateIdx === "number")
     );
 }
 


### PR DESCRIPTION
This PR adds an `itemUpdated` flag to `SPLICE.reportScoreAndState` messages so that apps can just update that item state that changed.

It also increase the consistency of the use of `docId`, using it in doc actions and making sure `extractSelectItemCredit` always reports the `docId`.