### PR TITLE
add showAnswerResponseMenu and answerResponseCountsByItem attributes

### DIFF
--- a/dev/testActivity.json
+++ b/dev/testActivity.json
@@ -16,7 +16,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>2+2=<answer>4</answer><selectFromSequence /></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 10,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -26,7 +26,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>1+1=<answer>2</answer><selectFromSequence length='3' /></problem><problem>4+4=<answer>8</answer><selectFromSequence length='4' /></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 12,
                     "baseComponentCounts": { "problem": 2 }
                 }
@@ -43,7 +43,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1A <graph><point name='P'/></graph><answer><award><when>$P.x > 0</when></award></answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 1,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -52,7 +52,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1B <p>Enter: <select assignNames='a'>a b c</select>. <answer>$a</answer></p></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 3,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -61,7 +61,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1C <p>Enter: <selectFromSequence assignNames='a' />. <answer>$a</answer></p></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 10,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -70,7 +70,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1D <p>Enter: <selectFromSequence assignNames='a' length=\"5\" />.  <answer>$a</answer></p></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 5,
                     "baseComponentCounts": { "question": 1 }
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
             "version": "0.1.0-alpha5",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@doenet/doenetml-iframe": "^0.7.0-alpha30",
+                "@doenet/doenetml-iframe": "^0.7.0-alpha32",
                 "nanoid": "^5.0.9",
                 "object-hash": "^3.0.0",
                 "react-icons": "^5.4.0",
-                "seedrandom": "^3.0.5",
-                "vite-plugin-dts": "^4.5.0"
+                "seedrandom": "^3.0.5"
             },
             "devDependencies": {
                 "@eslint/js": "^9.18.0",
@@ -32,6 +31,7 @@
                 "typescript": "~5.7.3",
                 "typescript-eslint": "^8.20.0",
                 "vite": "^6.0.7",
+                "vite-plugin-dts": "^4.5.0",
                 "vitest": "^3.0.4"
             },
             "peerDependencies": {
@@ -43,6 +43,7 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
             "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -52,6 +53,7 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
             "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -61,6 +63,7 @@
             "version": "7.26.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
             "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.26.7"
@@ -76,6 +79,7 @@
             "version": "7.26.7",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
             "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -86,9 +90,9 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.0-alpha30",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha30.tgz",
-            "integrity": "sha512-myfJxC+ThMnRT23CEkJz+vaWAn8LhokIb9uYWJvWFBTkHIHoVQj08NGQ/KJJPNiGXLb+s8OqITU6k71GBZ8EOw==",
+            "version": "0.7.0-alpha32",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha32.tgz",
+            "integrity": "sha512-SIBEnCepfQN+dPV2tmi2WdhF48ZLemMxkgETolsPsHhHFUBtt1wfA88ml9o7xsJk1OaYS21PQHMhJHKvts8vHg==",
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {
                 "react": "^18.3.1",
@@ -731,12 +735,14 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@microsoft/api-extractor": {
             "version": "7.49.2",
             "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.49.2.tgz",
             "integrity": "sha512-DI/WnvhbkHcucxxc4ys00ejCiViFls5EKPrEfe4NV3GGpVkoM5ZXF61HZNSGA8IG0oEV4KfTqIa59Rc3wdMopw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/api-extractor-model": "7.30.3",
@@ -761,6 +767,7 @@
             "version": "7.30.3",
             "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.3.tgz",
             "integrity": "sha512-yEAvq0F78MmStXdqz9TTT4PZ05Xu5R8nqgwI5xmUmQjWBQ9E6R2n8HB/iZMRciG4rf9iwI2mtuQwIzDXBvHn1w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "~0.15.1",
@@ -772,6 +779,7 @@
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
             "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -784,6 +792,7 @@
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
             "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -804,6 +813,7 @@
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -819,6 +829,7 @@
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
             "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -832,12 +843,14 @@
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
             "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@microsoft/tsdoc-config": {
             "version": "0.17.1",
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
             "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "0.15.1",
@@ -850,6 +863,7 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -866,12 +880,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
             "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -930,6 +946,7 @@
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
             "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
@@ -952,12 +969,14 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@rollup/pluginutils/node_modules/picomatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -1236,6 +1255,7 @@
             "version": "5.11.0",
             "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.11.0.tgz",
             "integrity": "sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -1260,6 +1280,7 @@
             "version": "8.13.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
             "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -1276,6 +1297,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -1290,12 +1312,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@rushstack/node-core-library/node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
             "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -1316,6 +1340,7 @@
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -1331,6 +1356,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
             "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "resolve": "~1.22.1",
@@ -1341,6 +1367,7 @@
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
             "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -1361,6 +1388,7 @@
             "version": "0.14.6",
             "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.6.tgz",
             "integrity": "sha512-4nMUy4h0u5PGXVG71kEA9uYI3l8GjVqewoHOFONiM6fuqS51ORdaJZ5ZXB2VZEGUyfg1TOTSy88MF2cdAy+lqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@rushstack/node-core-library": "5.11.0",
@@ -1379,6 +1407,7 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -1394,6 +1423,7 @@
             "version": "4.23.4",
             "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.4.tgz",
             "integrity": "sha512-pqmzDJCm0TS8VyeqnzcJ7ncwXgiLDQ6LVmXXfqv2nPL6VIz+UpyTpNVfZRJpyyJ+UDxqob1vIj2liaUfBjv8/A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@rushstack/terminal": "0.14.6",
@@ -1406,6 +1436,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -1641,12 +1672,14 @@
             "version": "1.0.38",
             "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
             "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json-schema": {
@@ -2034,6 +2067,7 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
             "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/source-map": "2.4.11"
@@ -2043,12 +2077,14 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
             "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@volar/typescript": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
             "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.11",
@@ -2060,6 +2096,7 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
             "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
@@ -2073,12 +2110,14 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@vue/compiler-dom": {
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
             "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-core": "3.5.13",
@@ -2089,6 +2128,7 @@
             "version": "2.7.16",
             "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
             "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "de-indent": "^1.0.2",
@@ -2099,6 +2139,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
             "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "~2.4.11",
@@ -2123,6 +2164,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -2132,6 +2174,7 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -2147,12 +2190,14 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
             "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "8.14.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
             "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -2192,6 +2237,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -2209,6 +2255,7 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -2225,12 +2272,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/alien-signals": {
             "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
             "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ansi-styles": {
@@ -2422,12 +2471,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -2585,18 +2636,21 @@
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
             "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/confbox": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
             "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cross-spawn": {
@@ -2679,12 +2733,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
             "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
             "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -2783,6 +2839,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -2973,7 +3030,7 @@
             "version": "0.24.2",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
             "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -3267,6 +3324,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -3317,6 +3375,7 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
             "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3417,6 +3476,7 @@
             "version": "11.3.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
             "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -3446,6 +3506,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3599,6 +3660,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/graphemer": {
@@ -3625,6 +3687,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3692,6 +3755,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3704,6 +3768,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "he": "bin/he"
@@ -3740,6 +3805,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
             "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3857,6 +3923,7 @@
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
             "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
@@ -4182,6 +4249,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
             "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-tokens": {
@@ -4228,6 +4296,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -4266,6 +4335,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
             "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/levn": {
@@ -4286,6 +4356,7 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
             "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mlly": "^1.7.3",
@@ -4318,6 +4389,7 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -4350,6 +4422,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -4362,6 +4435,7 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -4418,6 +4492,7 @@
             "version": "1.7.4",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
             "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "acorn": "^8.14.0",
@@ -4430,12 +4505,14 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/muggle-string": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
             "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -4664,6 +4741,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-exists": {
@@ -4690,12 +4768,14 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/pathe": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
             "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
@@ -4712,7 +4792,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -4732,6 +4812,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
             "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "confbox": "^0.1.8",
@@ -4753,7 +4834,7 @@
             "version": "8.5.1",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
             "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4782,7 +4863,7 @@
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
             "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -4839,6 +4920,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4956,6 +5038,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -5004,7 +5087,7 @@
             "version": "4.30.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
             "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.6"
@@ -5306,6 +5389,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -5315,6 +5399,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -5324,6 +5409,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/stackback": {
@@ -5344,6 +5430,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
             "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.6.19"
@@ -5451,6 +5538,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -5476,6 +5564,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -5649,6 +5738,7 @@
             "version": "5.7.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
             "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -5685,6 +5775,7 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
             "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unbox-primitive": {
@@ -5710,6 +5801,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
@@ -5719,6 +5811,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -5728,7 +5821,7 @@
             "version": "6.0.7",
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
             "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.24.2",
@@ -5823,6 +5916,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.0.tgz",
             "integrity": "sha512-M1lrPTdi7gilLYRZoLmGYnl4fbPryVYsehPN9JgaxjJKTs8/f7tuAlvCCvOLB5gRDQTTKnptBcB0ACsaw2wNLw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/api-extractor": "^7.49.1",
@@ -5919,6 +6013,7 @@
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
             "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/which": {
@@ -6056,6 +6151,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "react-dom": "^18.3.1"
     },
     "dependencies": {
-        "@doenet/doenetml-iframe": "^0.7.0-alpha30",
+        "@doenet/doenetml-iframe": "^0.7.0-alpha32",
         "nanoid": "^5.0.9",
         "object-hash": "^3.0.0",
         "react-icons": "^5.4.0",
@@ -56,8 +56,8 @@
         "typescript": "~5.7.3",
         "typescript-eslint": "^8.20.0",
         "vite": "^6.0.7",
-        "vitest": "^3.0.4",
-        "vite-plugin-dts": "^4.5.0"
+        "vite-plugin-dts": "^4.5.0",
+        "vitest": "^3.0.4"
     },
     "prettier": {
         "tabWidth": 4

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -14,7 +14,8 @@ export function Activity({
     forceUnsuppressCheckwork = false,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
+    answerResponseCountsByItem = [],
     state,
     doenetStates,
     reportScoreAndStateCallback,
@@ -37,7 +38,8 @@ export function Activity({
     forceUnsuppressCheckwork?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
+    answerResponseCountsByItem?: Record<string, number>[];
     state: ActivityState;
     doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
@@ -67,7 +69,8 @@ export function Activity({
                     forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                     linkSettings={linkSettings}
                     darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
+                    showAnswerResponseMenu={showAnswerResponseMenu}
+                    answerResponseCountsByItem={answerResponseCountsByItem}
                     state={state}
                     doenetStates={doenetStates}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
@@ -95,7 +98,8 @@ export function Activity({
                     forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                     linkSettings={linkSettings}
                     darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
+                    showAnswerResponseMenu={showAnswerResponseMenu}
+                    answerResponseCountsByItem={answerResponseCountsByItem}
                     state={state}
                     doenetStates={doenetStates}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}
@@ -123,7 +127,8 @@ export function Activity({
                     forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                     linkSettings={linkSettings}
                     darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
+                    showAnswerResponseMenu={showAnswerResponseMenu}
+                    answerResponseCountsByItem={answerResponseCountsByItem}
                     state={state}
                     doenetStates={doenetStates}
                     reportScoreAndStateCallback={reportScoreAndStateCallback}

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -14,7 +14,8 @@ export function SelectActivity({
     forceUnsuppressCheckwork = false,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
+    answerResponseCountsByItem = [],
     state,
     doenetStates,
     reportScoreAndStateCallback,
@@ -37,7 +38,8 @@ export function SelectActivity({
     forceUnsuppressCheckwork?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
+    answerResponseCountsByItem?: Record<string, number>[];
     state: SelectState;
     doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
@@ -72,7 +74,8 @@ export function SelectActivity({
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                 linkSettings={linkSettings}
                 darkMode={darkMode}
-                showAnswerTitles={showAnswerTitles}
+                showAnswerResponseMenu={showAnswerResponseMenu}
+                answerResponseCountsByItem={answerResponseCountsByItem}
                 reportScoreAndStateCallback={reportScoreAndStateCallback}
                 checkRender={checkRender}
                 checkHidden={checkHidden}

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -14,7 +14,8 @@ export function SequenceActivity({
     forceUnsuppressCheckwork = false,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
+    answerResponseCountsByItem = [],
     state,
     doenetStates,
     reportScoreAndStateCallback,
@@ -37,8 +38,9 @@ export function SequenceActivity({
     forceUnsuppressCheckwork?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
     state: SequenceState;
+    answerResponseCountsByItem?: Record<string, number>[];
     doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
@@ -71,7 +73,8 @@ export function SequenceActivity({
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                 linkSettings={linkSettings}
                 darkMode={darkMode}
-                showAnswerTitles={showAnswerTitles}
+                showAnswerResponseMenu={showAnswerResponseMenu}
+                answerResponseCountsByItem={answerResponseCountsByItem}
                 reportScoreAndStateCallback={reportScoreAndStateCallback}
                 checkRender={checkRender}
                 checkHidden={checkHidden}

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -14,7 +14,8 @@ export function SingleDocActivity({
     forceUnsuppressCheckwork = false,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
+    answerResponseCountsByItem = [],
     state,
     doenetStates,
     reportScoreAndStateCallback,
@@ -37,7 +38,8 @@ export function SingleDocActivity({
     forceUnsuppressCheckwork?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
+    answerResponseCountsByItem?: Record<string, number>[];
     state: SingleDocState;
     doenetStates: unknown[];
     reportScoreAndStateCallback: (args: unknown) => void;
@@ -155,7 +157,8 @@ export function SingleDocActivity({
                     forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                     linkSettings={linkSettings}
                     darkMode={darkMode}
-                    showAnswerTitles={showAnswerTitles}
+                    showAnswerResponseMenu={showAnswerResponseMenu}
+                    answerResponseCounts={answerResponseCountsByItem[itemIdx]}
                     addVirtualKeyboard={false}
                     initialState={initialDoenetState}
                     initializeCounters={initialCounters}

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -410,6 +410,7 @@ export function extractActivityItemCredit(
     docId: string;
     score: number;
     shuffledOrder: number;
+    variant: number;
 }[] {
     switch (activityState.type) {
         case "singleDoc": {

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -108,8 +108,6 @@ export function activityDoenetStateReducer(
             return action.state;
         }
         case "generateNewActivityAttempt": {
-            const firstAttempt = activityState.attemptNumber === 0;
-
             const { state: newActivityState } = generateNewActivityAttempt({
                 state: activityState,
                 numActivityVariants: action.numActivityVariants,
@@ -123,33 +121,22 @@ export function activityDoenetStateReducer(
 
             if (action.allowSaveState) {
                 const itemScores = extractActivityItemCredit(newActivityState);
-                if (firstAttempt) {
-                    // If first attempt, no need to save state.
-                    // Just send score by item to indicate how many items are in the activity
-                    const message: ReportScoreByItemMessage = {
-                        score: newActivityState.creditAchieved,
-                        itemScores,
-                        subject: "SPLICE.reportScoreByItem",
-                        activityId: action.baseId,
-                    };
-                    window.postMessage(message);
-                } else {
-                    const message: ReportStateMessage = {
-                        state: {
-                            activityState:
-                                pruneActivityStateForSave(newActivityState),
-                            doenetStates: [],
-                            itemAttemptNumbers: newItemAttemptNumbers,
-                            sourceHash: action.sourceHash,
-                        },
-                        score: newActivityState.creditAchieved,
-                        itemScores,
-                        subject: "SPLICE.reportScoreAndState",
-                        activityId: action.baseId,
-                        newAttempt: true,
-                    };
-                    window.postMessage(message);
-                }
+
+                const message: ReportStateMessage = {
+                    state: {
+                        activityState:
+                            pruneActivityStateForSave(newActivityState),
+                        doenetStates: [],
+                        itemAttemptNumbers: newItemAttemptNumbers,
+                        sourceHash: action.sourceHash,
+                    },
+                    score: newActivityState.creditAchieved,
+                    itemScores,
+                    subject: "SPLICE.reportScoreAndState",
+                    activityId: action.baseId,
+                    newAttempt: true,
+                };
+                window.postMessage(message);
             }
 
             return {

--- a/src/Activity/selectState.ts
+++ b/src/Activity/selectState.ts
@@ -23,6 +23,7 @@ import {
 } from "./activityState";
 
 import seedrandom from "seedrandom";
+import { SingleDocState } from "./singleDocState";
 
 const rngClass = seedrandom.alea;
 
@@ -624,6 +625,7 @@ export function extractSelectItemCredit(
     score: number;
     docId: string;
     shuffledOrder: number;
+    variant: number;
 }[] {
     if (activityState.attemptNumber === 0) {
         const nChildren = activityState.allChildren.length;
@@ -636,6 +638,7 @@ export function extractSelectItemCredit(
             score: number;
             docId: string;
             shuffledOrder: number;
+            variant: number;
         }[] = [];
         let nPrev = nPrevInShuffleOrder;
 
@@ -658,6 +661,8 @@ export function extractSelectItemCredit(
                 score: activityState.creditAchieved,
                 docId: activityState.selectedChildren[0].id,
                 shuffledOrder: nPrevInShuffleOrder + 1,
+                variant: (activityState.selectedChildren[0] as SingleDocState)
+                    .currentVariant,
             },
         ];
     } else {

--- a/src/Activity/sequenceState.ts
+++ b/src/Activity/sequenceState.ts
@@ -343,6 +343,7 @@ export function extractSequenceItemCredit(
     score: number;
     docId: string;
     shuffledOrder: number;
+    variant: number;
 }[] {
     if (activityState.attemptNumber === 0) {
         // just select the items in original order to give results that are at least in the right form

--- a/src/Activity/singleDocState.ts
+++ b/src/Activity/singleDocState.ts
@@ -261,6 +261,7 @@ export function extractSingleDocItemCredit(
     score: number;
     docId: string;
     shuffledOrder: number;
+    variant: number;
 }[] {
     if (activityState.source.isDescription) {
         return [];
@@ -271,6 +272,7 @@ export function extractSingleDocItemCredit(
                 score: activityState.creditAchieved,
                 docId: activityState.id,
                 shuffledOrder: nPrevInShuffleOrder + 1,
+                variant: activityState.currentVariant,
             },
         ];
     }

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -34,7 +34,7 @@ export function Viewer({
     flags,
     activityId,
     userId = null,
-    variantIndex: initialVariantIndex,
+    initialVariantIndex,
     maxAttemptsAllowed = 1,
     itemLevelAttempts = false,
     activityLevelAttempts = false,
@@ -48,14 +48,15 @@ export function Viewer({
     externalVirtualKeyboardProvided: _externalVirtualKeyboardProvided = false,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
+    answerResponseCountsByItem = [],
     showTitle = true,
 }: {
     source: ActivitySource;
     flags: DoenetMLFlags;
     activityId: string;
     userId?: string | null;
-    variantIndex: number;
+    initialVariantIndex: number;
     maxAttemptsAllowed?: number;
     itemLevelAttempts?: boolean;
     activityLevelAttempts?: boolean;
@@ -69,7 +70,8 @@ export function Viewer({
     externalVirtualKeyboardProvided?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
+    answerResponseCountsByItem?: Record<string, number>[];
     showTitle?: boolean;
 }) {
     const [errMsg, setErrMsg] = useState<string | null>(null);
@@ -558,7 +560,8 @@ export function Viewer({
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                 linkSettings={linkSettings}
                 darkMode={darkMode}
-                showAnswerTitles={showAnswerTitles}
+                showAnswerResponseMenu={showAnswerResponseMenu}
+                answerResponseCountsByItem={answerResponseCountsByItem}
                 state={activityState}
                 doenetStates={activityDoenetState.doenetStates}
                 reportScoreAndStateCallback={reportScoreAndStateCallback}

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -47,7 +47,8 @@ export function ActivityViewer({
     externalVirtualKeyboardProvided = false,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
+    answerResponseCountsByItem = [],
     includeVariantSelector: _includeVariantSelector = false,
     showTitle = true,
 }: {
@@ -69,7 +70,8 @@ export function ActivityViewer({
     externalVirtualKeyboardProvided?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
+    answerResponseCountsByItem?: Record<string, number>[];
     includeVariantSelector?: boolean;
     showTitle?: boolean;
 }) {
@@ -79,7 +81,9 @@ export function ActivityViewer({
     //     allPossibleVariants: ["a"],
     // });
 
-    const [variantIndex, setVariantIndex] = useState<number | null>(null);
+    const [initialVariantIndex, setInitialVariantIndex] = useState<
+        number | null
+    >(null);
 
     const thisPropSet: PropSet = {
         source: JSON.stringify(source),
@@ -106,9 +110,9 @@ export function ActivityViewer({
     if (foundPropChange) {
         if (requestedVariantIndex === undefined) {
             const rng = rngClass(new Date().toString());
-            setVariantIndex(Math.floor(rng() * 1000000) + 1);
+            setInitialVariantIndex(Math.floor(rng() * 1000000) + 1);
         } else {
-            setVariantIndex(
+            setInitialVariantIndex(
                 Number.isInteger(requestedVariantIndex)
                     ? requestedVariantIndex
                     : 1,
@@ -116,7 +120,7 @@ export function ActivityViewer({
         }
     }
 
-    if (variantIndex === null) {
+    if (initialVariantIndex === null) {
         return null;
     }
 
@@ -127,7 +131,7 @@ export function ActivityViewer({
                 flags={flags}
                 activityId={activityId}
                 userId={userId}
-                variantIndex={variantIndex}
+                initialVariantIndex={initialVariantIndex}
                 maxAttemptsAllowed={maxAttemptsAllowed}
                 itemLevelAttempts={itemLevelAttempts}
                 activityLevelAttempts={activityLevelAttempts}
@@ -143,7 +147,8 @@ export function ActivityViewer({
                 }
                 linkSettings={linkSettings}
                 darkMode={darkMode}
-                showAnswerTitles={showAnswerTitles}
+                showAnswerResponseMenu={showAnswerResponseMenu}
+                answerResponseCountsByItem={answerResponseCountsByItem}
                 showTitle={showTitle}
             />
         </ErrorBoundary>

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -138,6 +138,7 @@ describe("Activity reducer tests", () => {
                         score: 0,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: 0,
                     },
                 ],
                 activityId: "newId",
@@ -224,7 +225,7 @@ describe("Activity reducer tests", () => {
 
         expect(spy.mock.lastCall).eqls([
             {
-                subject: "SPLICE.reportScoreByItem",
+                subject: "SPLICE.reportScoreAndState",
                 score: 0,
                 itemScores: [
                     {
@@ -232,9 +233,17 @@ describe("Activity reducer tests", () => {
                         score: 0,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
+                state: {
+                    activityState: pruneActivityStateForSave(activityState),
+                    sourceHash,
+                    doenetStates: [],
+                    itemAttemptNumbers: [1],
+                },
                 activityId: "newId",
+                newAttempt: true,
             },
         ]);
 
@@ -273,6 +282,7 @@ describe("Activity reducer tests", () => {
                         score: 0,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 state: {
@@ -364,6 +374,7 @@ describe("Activity reducer tests", () => {
                         score: 0.2,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 itemUpdated: 1,
@@ -423,6 +434,7 @@ describe("Activity reducer tests", () => {
                         score: 0.1,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 itemUpdated: 1,
@@ -482,6 +494,7 @@ describe("Activity reducer tests", () => {
                         score: 0.3,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 itemUpdated: 1,
@@ -533,6 +546,7 @@ describe("Activity reducer tests", () => {
                         score: 0,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 state: {
@@ -589,6 +603,7 @@ describe("Activity reducer tests", () => {
                         score: 0.1,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 itemUpdated: 1,
@@ -648,6 +663,7 @@ describe("Activity reducer tests", () => {
                         score: 0.5,
                         docId: "doc5",
                         shuffledOrder: 1,
+                        variant: activityState.currentVariant,
                     },
                 ],
                 itemUpdated: 1,
@@ -711,6 +727,8 @@ describe("Activity reducer tests", () => {
 
         expect(activityState.attemptNumber).eq(attemptNumber);
 
+        const docVariants: number[] = [];
+
         for (let i = 0; i < 3; i++) {
             const docState = activityState.orderedChildren[i];
             if (docState.type !== "singleDoc") {
@@ -729,6 +747,8 @@ describe("Activity reducer tests", () => {
                     docStates[i],
                 );
             }
+
+            docVariants.push(docState.currentVariant);
         }
 
         const newInfoObj: {
@@ -761,6 +781,7 @@ describe("Activity reducer tests", () => {
                         score: docCredits[idx],
                         docId: docIds[idx],
                         shuffledOrder: idx + 1,
+                        variant: docVariants[idx],
                     };
                 }),
                 state: {
@@ -1345,6 +1366,8 @@ describe("Activity reducer tests", () => {
 
         expect(activityState.attemptNumber).eq(attemptNumber);
 
+        const docVariants: number[] = [];
+
         for (let i = 0; i < 2; i++) {
             const selectState = activityState.orderedChildren[i];
             if (selectState.type !== "select") {
@@ -1371,6 +1394,8 @@ describe("Activity reducer tests", () => {
                     docStates[i],
                 );
             }
+
+            docVariants.push(docState.currentVariant);
         }
 
         const newInfoObj: {
@@ -1403,6 +1428,7 @@ describe("Activity reducer tests", () => {
                         score: selCredits[idx],
                         docId: docIds[idx],
                         shuffledOrder: idx + 1,
+                        variant: docVariants[idx],
                     };
                 }),
                 state: {
@@ -2122,12 +2148,14 @@ describe("Activity reducer tests", () => {
                         score: docCredits[0],
                         docId: docIds[0],
                         shuffledOrder: 1,
+                        variant: Number(docIds[0].split("|")[1]),
                     },
                     {
                         id: docIds[1],
                         score: docCredits[1],
                         docId: docIds[1],
                         shuffledOrder: 2,
+                        variant: Number(docIds[1].split("|")[1]),
                     },
                 ],
                 state: {

--- a/src/test/testSources/doc.json
+++ b/src/test/testSources/doc.json
@@ -3,7 +3,7 @@
     "type": "singleDoc",
     "isDescription": false,
     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-    "version": "0.7.0-alpha30",
+    "version": "0.7.0-alpha32",
     "numVariants": 5,
     "baseComponentCounts": { "problem": 1 }
 }

--- a/src/test/testSources/duplicateId.json
+++ b/src/test/testSources/duplicateId.json
@@ -9,14 +9,14 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha32"
         },
         {
             "id": "seq",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha32"
         }
     ]
 }

--- a/src/test/testSources/invalidId.json
+++ b/src/test/testSources/invalidId.json
@@ -9,14 +9,14 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha32"
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30"
+            "version": "0.7.0-alpha32"
         }
     ]
 }

--- a/src/test/testSources/sel.json
+++ b/src/test/testSources/sel.json
@@ -10,7 +10,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": { "question": 1 }
         },
@@ -19,7 +19,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -28,7 +28,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         }

--- a/src/test/testSources/sel2seq.json
+++ b/src/test/testSources/sel2seq.json
@@ -15,7 +15,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 4,
                     "baseComponentCounts": { "problem": 1 }
                 },
@@ -24,7 +24,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 5,
                     "baseComponentCounts": { "problem": 1 }
                 }
@@ -40,7 +40,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 3,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -49,7 +49,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 1,
                     "baseComponentCounts": { "question": 1 }
                 }

--- a/src/test/testSources/selMult1doc.json
+++ b/src/test/testSources/selMult1doc.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         }

--- a/src/test/testSources/selMult1docNoVariant.json
+++ b/src/test/testSources/selMult1docNoVariant.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         }

--- a/src/test/testSources/selMult2docs.json
+++ b/src/test/testSources/selMult2docs.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         }

--- a/src/test/testSources/selMult2seq.json
+++ b/src/test/testSources/selMult2seq.json
@@ -15,7 +15,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 4,
                     "baseComponentCounts": { "problem": 1 }
                 },
@@ -24,7 +24,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 5,
                     "baseComponentCounts": { "problem": 1 }
                 }
@@ -40,7 +40,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 3,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -49,7 +49,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 2,
                     "baseComponentCounts": { "question": 1 }
                 }

--- a/src/test/testSources/selMult4docsNoVariant.json
+++ b/src/test/testSources/selMult4docsNoVariant.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -27,7 +27,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": { "question": 1 }
         },
@@ -36,7 +36,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 2,
             "baseComponentCounts": { "question": 1 }
         }

--- a/src/test/testSources/selNoVariant.json
+++ b/src/test/testSources/selNoVariant.json
@@ -10,7 +10,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": { "question": 1 }
         },
@@ -19,7 +19,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -28,7 +28,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         }

--- a/src/test/testSources/seq.json
+++ b/src/test/testSources/seq.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -27,7 +27,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": { "question": 1 }
         }

--- a/src/test/testSources/seq2sel.json
+++ b/src/test/testSources/seq2sel.json
@@ -15,7 +15,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 4,
                     "baseComponentCounts": { "problem": 1 }
                 },
@@ -24,7 +24,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 5,
                     "baseComponentCounts": { "problem": 1 }
                 }
@@ -41,7 +41,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 3,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -50,7 +50,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 2,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -59,7 +59,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 1,
                     "baseComponentCounts": { "question": 1 }
                 }

--- a/src/test/testSources/seqSel0Sel.json
+++ b/src/test/testSources/seqSel0Sel.json
@@ -22,7 +22,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 3,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -31,7 +31,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 2,
                     "baseComponentCounts": { "question": 1 }
                 },
@@ -40,7 +40,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-alpha30",
+                    "version": "0.7.0-alpha32",
                     "numVariants": 1,
                     "baseComponentCounts": { "question": 1 }
                 }

--- a/src/test/testSources/seqShuf.json
+++ b/src/test/testSources/seqShuf.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": { "question": 1 }
         },
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -27,7 +27,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         }

--- a/src/test/testSources/seqWithDes.json
+++ b/src/test/testSources/seqWithDes.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": true,
             "doenetML": "Title page",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": {}
         },
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 4,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -27,7 +27,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 2,
             "baseComponentCounts": { "question": 1 }
         },
@@ -36,7 +36,7 @@
             "type": "singleDoc",
             "isDescription": true,
             "doenetML": "Intermediate instructions <selectFromSequence length='3' />",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 3,
             "baseComponentCounts": {}
         },
@@ -45,7 +45,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 5,
             "baseComponentCounts": { "problem": 1 }
         },
@@ -54,7 +54,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 1,
             "baseComponentCounts": { "question": 1 }
         },
@@ -63,7 +63,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha32",
             "numVariants": 3,
             "baseComponentCounts": { "question": 1 }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,8 +81,9 @@ export type ReportStateMessage = {
     itemScores: {
         id: string;
         score: number;
-        docId?: string;
+        docId: string;
         shuffledOrder: number;
+        variant: number;
     }[];
     itemUpdated?: number;
     state: ExportedActivityState;
@@ -107,8 +108,9 @@ export function isReportStateMessage(obj: unknown): obj is ReportStateMessage {
             (item) =>
                 typeof item.id === "string" &&
                 typeof item.score === "number" &&
-                (item.docId === undefined || typeof item.docId === "string") &&
-                typeof item.shuffledOrder === "number",
+                typeof item.docId === "string" &&
+                typeof item.shuffledOrder === "number" &&
+                typeof item.variant === "number",
         ) &&
         (typedObj.itemUpdated === undefined ||
             typeof typedObj.itemUpdated === "number") &&
@@ -129,8 +131,9 @@ export type ReportScoreByItemMessage = {
     itemScores: {
         id: string;
         score: number;
-        docId?: string;
+        docId: string;
         shuffledOrder: number;
+        variant: number;
     }[];
 };
 
@@ -152,8 +155,9 @@ export function isReportScoreByItemMessage(
             (item) =>
                 typeof item.id === "string" &&
                 typeof item.score === "number" &&
-                (item.docId === undefined || typeof item.docId === "string") &&
-                typeof item.shuffledOrder === "number",
+                typeof item.docId === "string" &&
+                typeof item.shuffledOrder === "number" &&
+                typeof item.variant === "number",
         )
     );
 }


### PR DESCRIPTION
This PR adds `showAnswerResponseMenu` and `answerResponseCountsByItem` attributes that link to the comparable attributes added to DoenetML in Doenet/DoenetML#296. The attributes give the containing app the ability to add a button next to each answer that links to the list of responses to that answer. 

The PR also adds `variant` to more reporting objects and reports the state even after the first attempt is created.

