### PR TITLE
Remove DoenetML version when creating source hash

### DIFF
--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -657,7 +657,7 @@ export function validateStateAndSource(state: unknown, source: unknown) {
         return false;
     }
 
-    const sourceHash = hash(source);
+    const sourceHash = createSourceHash(source);
 
     return state.sourceHash === sourceHash;
 }
@@ -782,4 +782,24 @@ export function propagateStateChangeToRoot({
         allStates,
         id: newParentState.id,
     });
+}
+
+/** Return source with the version field set to an empty string in all documents */
+function removeVersionFromSource(source: ActivitySource): ActivitySource {
+    if (source.type === "singleDoc") {
+        return {
+            ...source,
+            version: "",
+        };
+    } else {
+        return {
+            ...source,
+            items: source.items.map(removeVersionFromSource),
+        };
+    }
+}
+
+/** Create a hash of the source after setting the version field to an empty string in all documents */
+export function createSourceHash(source: ActivitySource) {
+    return hash(removeVersionFromSource(source));
 }

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -24,10 +24,10 @@ import {
     getNumItems,
     ActivityAndDoenetState,
     isActivityAndDoenetState,
+    createSourceHash,
 } from "../Activity/activityState";
 import { Activity } from "../Activity/Activity";
 import { activityDoenetStateReducer } from "../Activity/activityStateReducer";
-import hash from "object-hash";
 
 export function Viewer({
     source,
@@ -83,7 +83,7 @@ export function Viewer({
             try {
                 validateIds(source);
                 const docStructure = gatherDocumentStructure(source);
-                const sourceHash = hash(source);
+                const sourceHash = createSourceHash(source);
                 const numItems = getNumItems(source);
                 return { ...docStructure, sourceHash, numItems };
             } catch (e) {

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, MockInstance, vi } from "vitest";
 import { SequenceSource } from "../Activity/sequenceState";
 import {
     ActivityAndDoenetState,
+    createSourceHash,
     gatherDocumentStructure,
     initializeActivityState,
     pruneActivityStateForSave,
@@ -13,7 +14,6 @@ import seqShuf from "./testSources/seqShuf.json";
 import selMult2docs from "./testSources/selMult2docs.json";
 import { SingleDocSource, SingleDocState } from "../Activity/singleDocState";
 import { SelectSource, SelectState } from "../Activity/selectState";
-import hash from "object-hash";
 
 describe("Activity reducer tests", () => {
     afterEach(() => {
@@ -154,7 +154,7 @@ describe("Activity reducer tests", () => {
 
         const source = doc as SingleDocSource;
         const { numActivityVariants } = gatherDocumentStructure(source);
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const state0 = initializeActivityState({
             source: source,
@@ -308,7 +308,7 @@ describe("Activity reducer tests", () => {
 
         const source = doc as SingleDocSource;
         const { numActivityVariants } = gatherDocumentStructure(source);
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const state0 = initializeActivityState({
             source: source,
@@ -812,7 +812,7 @@ describe("Activity reducer tests", () => {
         const spy = vi.spyOn(window, "postMessage");
 
         const source = seqShuf as SequenceSource;
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
@@ -1006,7 +1006,7 @@ describe("Activity reducer tests", () => {
         const spy = vi.spyOn(window, "postMessage");
 
         const source = seqShuf as SequenceSource;
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
@@ -1459,7 +1459,7 @@ describe("Activity reducer tests", () => {
         const spy = vi.spyOn(window, "postMessage");
 
         const source = seq2sel as SequenceSource;
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
@@ -1701,7 +1701,7 @@ describe("Activity reducer tests", () => {
         const spy = vi.spyOn(window, "postMessage");
 
         const source = seq2sel as SequenceSource;
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 
@@ -2186,7 +2186,7 @@ describe("Activity reducer tests", () => {
         const spy = vi.spyOn(window, "postMessage");
 
         const source = selMult2docs as SelectSource;
-        const sourceHash = hash(source);
+        const sourceHash = createSourceHash(source);
 
         const { numActivityVariants } = gatherDocumentStructure(source);
 


### PR DESCRIPTION
This PR removes the DoenetML version when creating the source hash used to determined if exported state matches the source.

When the version was included, upgrading the version of DoenetML causes all loading of state to fail, as the source no longer matches.

Once we get version numbering standardized, we could include just the major DoenetML version so that loading the state would fail only if backwards incompatible changes to DoenetML were made.