### PR TITLE
fix regressions from new version of DoenetML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha7",
+    "version": "0.1.0-alpha8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha7",
+            "version": "0.1.0-alpha8",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@doenet/doenetml-iframe": "^0.7.0-alpha52",
                 "nanoid": "^5.1.5",
                 "object-hash": "^3.0.0",
                 "react-icons": "^5.5.0",
@@ -36,6 +35,7 @@
                 "vitest": "^3.2.4"
             },
             "peerDependencies": {
+                "@doenet/doenetml-iframe": "^0.7.0-alpha53",
                 "react": "^19.1.1",
                 "react-dom": "^19.1.1"
             }
@@ -91,10 +91,11 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.0-alpha52",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha52.tgz",
-            "integrity": "sha512-V9wfN9pUxxivGDBX5xemTi+VuhIwyn6ncyOfOhF3lGq10pFWAkiR1OwHEdIcrSKBmSZWD7+0yK14I732qWRSSQ==",
+            "version": "0.7.0-alpha53",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha53.tgz",
+            "integrity": "sha512-oYxNuqYMnBS4JDA5/A8V3uww+Qea/f9h5HXkEr0kThbIKZCu2+GY/YLfWeo7mlobs1MPJWwuCtwjyZnVYAvbwA==",
             "license": "AGPL-3.0-or-later",
+            "peer": true,
             "peerDependencies": {
                 "react": "^19.1.1",
                 "react-dom": "^19.1.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha7",
+    "version": "0.1.0-alpha8",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",
@@ -31,10 +31,10 @@
     },
     "peerDependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "@doenet/doenetml-iframe": "^0.7.0-alpha53"
     },
     "dependencies": {
-        "@doenet/doenetml-iframe": "^0.7.0-alpha52",
         "nanoid": "^5.1.5",
         "object-hash": "^3.0.0",
         "react-icons": "^5.5.0",

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -341,10 +341,10 @@ export function Viewer({
             activityDoenetStateDispatch({
                 type: "updateSingleState",
                 docId: msg.docId,
-                doenetState: msg.state,
+                doenetState: msg.data.state,
                 doenetStateIdx: itemSequence.indexOf(msg.docId),
                 itemSequence,
-                creditAchieved: msg.score,
+                creditAchieved: msg.data.score,
                 allowSaveState: flags.allowSaveState,
                 baseId: activityId,
                 sourceHash,

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,22 +53,27 @@ export function isDocumentStructureData(
 export type singleDocReportStateMessage = {
     activityId: string;
     docId: string;
-    score: number;
-    state: unknown;
+    data: {
+        score: number;
+        state: unknown;
+    };
 };
 
 export function isSingleDocReportStateMessage(
     obj: unknown,
 ): obj is singleDocReportStateMessage {
-    const typeObj = obj as singleDocReportStateMessage;
+    const typedObj = obj as singleDocReportStateMessage;
 
     return (
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        typeObj !== null &&
-        typeof typeObj === "object" &&
-        typeof typeObj.activityId === "string" &&
-        typeof typeObj.docId === "string" &&
-        typeof typeObj.score === "number"
+        typedObj !== null &&
+        typeof typedObj === "object" &&
+        typeof typedObj.activityId === "string" &&
+        typeof typedObj.docId === "string" &&
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        typedObj.data !== null &&
+        typeof typedObj.data === "object" &&
+        typeof typedObj.data.score === "number"
     );
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ const fullReloadAlways: Plugin = {
 };
 
 // These are the dependencies that will not be bundled into the library.
-const EXTERNAL_DEPS = ["react", "react-dom"];
+const EXTERNAL_DEPS = ["react", "react-dom", "@doenet/doenetml-iframe"];
 
 export default defineConfig({
     plugins: [react(), dts(), fullReloadAlways],


### PR DESCRIPTION
This PR fixes regressions due to a change in the message format of DoenetML's update score and state message.

It also changes `doenetml-iframe` to a peer dependency.