### PR TITLE
remove prefixForIds from DoenetViewer

### DIFF
--- a/dev/testActivity.json
+++ b/dev/testActivity.json
@@ -16,7 +16,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>2+2=<answer>4</answer><selectFromSequence /></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 10
                 },
                 {
@@ -25,7 +25,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>1+1=<answer>2</answer><selectFromSequence length='3' /></problem><problem>4+4=<answer>8</answer><selectFromSequence length='4' /></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 12
                 }
             ]
@@ -41,7 +41,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1A <graph><point name='P'/></graph><answer><award><when>$P.x > 0</when></award></answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 1
                 },
                 {
@@ -49,7 +49,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1B <p>Enter: <select name='a'>a b c</select>. <answer>$a</answer></p></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 3
                 },
                 {
@@ -57,7 +57,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1C <p>Enter: <selectFromSequence name='a' />. <answer>$a</answer></p></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 10
                 },
                 {
@@ -65,7 +65,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1D <p>Enter: <selectFromSequence name='a' length=\"5\" />.  <answer>$a</answer></p></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 5
                 }
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha-13",
+    "version": "0.1.0-alpha-14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha-13",
+            "version": "0.1.0-alpha-14",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "nanoid": "^5.1.6",
@@ -35,7 +35,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "^0.7.0-rc-2",
+                "@doenet/doenetml-iframe": "^0.7.4",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }
@@ -282,9 +282,9 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.0-rc-2",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-rc-2.tgz",
-            "integrity": "sha512-wzuU33SrAiBBZA0sOG4B2zx2fW3oLKOouMSGXxJIlTCM8IgndzL7gfgXKG6PkKqRgiBH03HmwsB1/hCSGeoXlA==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.4.tgz",
+            "integrity": "sha512-frAkDbgXi9KCXBmew+Ol6pA1qbJrMbfsFY3XaBGroAYaQx82SXtgj5YIq0qHTqfnDaFpuMCJpr6hMiOG8247OA==",
             "license": "AGPL-3.0-or-later",
             "peer": true,
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha-13",
+    "version": "0.1.0-alpha-14",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",
@@ -35,7 +35,7 @@
     "peerDependencies": {
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
-        "@doenet/doenetml-iframe": "^0.7.0-rc-2"
+        "@doenet/doenetml-iframe": "^0.7.4"
     },
     "dependencies": {
         "nanoid": "^5.1.6",

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -164,7 +164,6 @@ export function SingleDocActivity({
                     requestedVariantIndex={requestedVariantIndex}
                     flags={flags}
                     activityId={baseId}
-                    prefixForIds={state.id}
                     docId={state.id}
                     forceDisable={forceDisable}
                     forceShowCorrectness={forceShowCorrectness}

--- a/src/test/testSources/doc.json
+++ b/src/test/testSources/doc.json
@@ -3,6 +3,6 @@
     "type": "singleDoc",
     "isDescription": false,
     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-    "version": "0.7.0-beta16",
+    "version": "0.7.4",
     "numVariants": 5
 }

--- a/src/test/testSources/duplicateId.json
+++ b/src/test/testSources/duplicateId.json
@@ -9,14 +9,14 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16"
+            "version": "0.7.4"
         },
         {
             "id": "seq",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16"
+            "version": "0.7.4"
         }
     ]
 }

--- a/src/test/testSources/invalidId.json
+++ b/src/test/testSources/invalidId.json
@@ -9,14 +9,14 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16"
+            "version": "0.7.4"
         },
         {
             "id": "doc5",
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16"
+            "version": "0.7.4"
         }
     ]
 }

--- a/src/test/testSources/sel.json
+++ b/src/test/testSources/sel.json
@@ -10,7 +10,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         },
         {
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         },
         {
@@ -26,7 +26,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         }
     ]

--- a/src/test/testSources/sel2seq.json
+++ b/src/test/testSources/sel2seq.json
@@ -15,7 +15,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 4
                 },
                 {
@@ -23,7 +23,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 5
                 }
             ]
@@ -38,7 +38,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 3
                 },
                 {
@@ -46,7 +46,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 1
                 }
             ]

--- a/src/test/testSources/selMult1doc.json
+++ b/src/test/testSources/selMult1doc.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         }
     ]

--- a/src/test/testSources/selMult1docNoVariant.json
+++ b/src/test/testSources/selMult1docNoVariant.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         }
     ]

--- a/src/test/testSources/selMult2docs.json
+++ b/src/test/testSources/selMult2docs.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         },
         {
@@ -17,7 +17,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         }
     ]

--- a/src/test/testSources/selMult2seq.json
+++ b/src/test/testSources/selMult2seq.json
@@ -15,7 +15,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 4
                 },
                 {
@@ -23,7 +23,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 5
                 }
             ]
@@ -38,7 +38,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 3
                 },
                 {
@@ -46,7 +46,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 2
                 }
             ]

--- a/src/test/testSources/selMult4docsNoVariant.json
+++ b/src/test/testSources/selMult4docsNoVariant.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         },
         {
@@ -17,7 +17,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         },
         {
@@ -25,7 +25,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         },
         {
@@ -33,7 +33,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 2
         }
     ]

--- a/src/test/testSources/selNoVariant.json
+++ b/src/test/testSources/selNoVariant.json
@@ -10,7 +10,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         },
         {
@@ -18,7 +18,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         },
         {
@@ -26,7 +26,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         }
     ]

--- a/src/test/testSources/seq.json
+++ b/src/test/testSources/seq.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         },
         {
@@ -17,7 +17,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         },
         {
@@ -25,7 +25,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         }
     ]

--- a/src/test/testSources/seq2sel.json
+++ b/src/test/testSources/seq2sel.json
@@ -15,7 +15,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 4
                 },
                 {
@@ -23,7 +23,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 5
                 }
             ]
@@ -39,7 +39,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 3
                 },
                 {
@@ -47,7 +47,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 2
                 },
                 {
@@ -55,7 +55,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 1
                 }
             ]

--- a/src/test/testSources/seqSel0Sel.json
+++ b/src/test/testSources/seqSel0Sel.json
@@ -22,7 +22,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 3
                 },
                 {
@@ -30,7 +30,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 2
                 },
                 {
@@ -38,7 +38,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-                    "version": "0.7.0-beta16",
+                    "version": "0.7.4",
                     "numVariants": 1
                 }
             ]

--- a/src/test/testSources/seqShuf.json
+++ b/src/test/testSources/seqShuf.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         },
         {
@@ -17,7 +17,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         },
         {
@@ -25,7 +25,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         }
     ]

--- a/src/test/testSources/seqWithDes.json
+++ b/src/test/testSources/seqWithDes.json
@@ -9,7 +9,7 @@
             "type": "singleDoc",
             "isDescription": true,
             "doenetML": "Title page",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         },
         {
@@ -17,7 +17,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='1' to='4' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 4
         },
         {
@@ -25,7 +25,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='h' to='i' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 2
         },
         {
@@ -33,7 +33,7 @@
             "type": "singleDoc",
             "isDescription": true,
             "doenetML": "Intermediate instructions <selectFromSequence length='3' />",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 3
         },
         {
@@ -41,7 +41,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<problem>Enter <selectFromSequence name='n' from='11' to='15' />: <answer name='ans'>$n</answer></problem>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 5
         },
         {
@@ -49,7 +49,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <text name='a'>z</text>: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 1
         },
         {
@@ -57,7 +57,7 @@
             "type": "singleDoc",
             "isDescription": false,
             "doenetML": "<question>Enter <selectFromSequence name='a' type='letters' from='a' to='c' />: <answer name='ans'>$a</answer></question>",
-            "version": "0.7.0-beta16",
+            "version": "0.7.4",
             "numVariants": 3
         }
     ]


### PR DESCRIPTION
This PR removes the `prefixForIds` argument to `<DoenetViewer>`. The additional complexity is not needed since each document is in its own iframe.

The PR also bumps the version and upgrades DoenetML to 0.7.4.