### PR TITLE
add data-test attributes for testing

### DIFF
--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -203,7 +203,7 @@ export function SingleDocActivity({
                                 ? "not-allowed"
                                 : "pointer",
                         }}
-                        data-test="New Item Attempt Button"
+                        data-test="New Item Attempt"
                     >
                         New {itemWord} attempt{" "}
                         {maxAttemptsAllowed > 0

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -203,6 +203,7 @@ export function SingleDocActivity({
                                 ? "not-allowed"
                                 : "pointer",
                         }}
+                        data-test="New Item Attempt Button"
                     >
                         New {itemWord} attempt{" "}
                         {maxAttemptsAllowed > 0

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -487,6 +487,7 @@ export function Viewer({
                             borderRadius: "10px",
                             padding: "5px 20px",
                         }}
+                        data-test="Cancel Create New Attempt"
                     >
                         Cancel
                     </button>
@@ -505,6 +506,7 @@ export function Viewer({
                             borderRadius: "10px",
                             padding: "5px 20px",
                         }}
+                        data-test="Confirm Create New Attempt"
                     >
                         Create new attempt
                     </button>


### PR DESCRIPTION
This PR add some `data-test` attribute to new attempt buttons to help with cypress tests in DoenetTools.