### PR TITLE
Add GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches: ["main"]
     pull_request:
-        branches: ["*"]
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
     push:
+        branches: ["main"]
     pull_request:
+        branches: ["*"]
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,11 @@ name: CI
 
 on:
     push:
-        branches: ["main"]
     pull_request:
-        branches: ["*"]
     workflow_dispatch:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -58,7 +56,6 @@ jobs:
     test-vitest:
         name: Vitest Tests
         runs-on: ubuntu-latest
-        needs: build
         strategy:
             matrix:
                 node-version: [24.15.0]
@@ -76,7 +73,6 @@ jobs:
     test-cypress:
         name: Cypress Component Tests
         runs-on: ubuntu-latest
-        needs: build
         strategy:
             matrix:
                 # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+    push:
+        branches: ["main"]
+    pull_request:
+        branches: ["*"]
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+            - name: Build
+              run: npm run build
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v7
+              with:
+                  name: build-artifacts
+                  path: ./dist
+
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [24.15.0]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+            - name: Lint
+              run: npm run lint
+
+    test-vitest:
+        name: Vitest Tests
+        runs-on: ubuntu-latest
+        needs: build
+        strategy:
+            matrix:
+                node-version: [24.15.0]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+            - name: Test
+              run: npm run test -- --run
+
+    test-cypress:
+        name: Cypress Component Tests
+        runs-on: ubuntu-latest
+        needs: build
+        strategy:
+            matrix:
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+            - name: Cypress run
+              run: npm run test-cypress-all
+            - name: Upload screenshots on failure
+              if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: cypress-screenshots
+                  path: ./cypress/screenshots
+                  if-no-files-found: ignore


### PR DESCRIPTION
Stacked on #32 (add that PR's `dark-mode` branch as base once merged, or review together).

Adds a CI workflow with four jobs that run on every push and pull request:

| Job | What it does |
|-----|-------------|
| **Build** | `npm run build`, uploads `dist/` as an artifact |
| **Lint** | `npm run lint` |
| **Vitest Tests** | `npm run test` (existing unit tests) |
| **Cypress Component Tests** | `npm run test-cypress-all` (headless Chrome), uploads screenshots on failure |

Action versions match DoenetML's CI (`actions/checkout@v6`, `actions/setup-node@v6`, `actions/upload-artifact@v7`). Node pinned to 24.15.0 to avoid the 24.16.0 extract-zip regression that hangs Cypress install scripts.