### PR TITLE
Render hygiene, self-clearing error state, and report-flow hardening

### DIFF
--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -1,37 +1,11 @@
+import { memo } from "react";
 import { DoenetMLFlags } from "../types";
 import { ActivityState } from "./activityState";
 import { SelectActivity } from "./SelectActivity";
 import { SequenceActivity } from "./SequenceActivity";
 import { SingleDocActivity } from "./SingleDocActivity";
 
-export function Activity({
-    flags,
-    baseId,
-    maxAttemptsAllowed,
-    forceDisable = false,
-    forceShowCorrectness = false,
-    forceShowSolution = false,
-    forceUnsuppressCheckwork = false,
-    doenetViewerUrl,
-    fetchExternalDoenetML,
-    darkMode = "light",
-    showAnswerResponseMenu = false,
-    answerResponseCountsByItem = [],
-    state,
-    doenetStates,
-    loadedStateNum,
-    reportScoreAndStateCallback,
-    checkRender,
-    checkHidden,
-    allowItemAttemptButtons = false,
-    generateNewItemAttempt,
-    hasRenderedCallback,
-    reportVisibility = false,
-    reportVisibilityCallback,
-    itemAttemptNumbers,
-    itemSequence,
-    itemWord,
-}: {
+export type ActivityCommonProps = {
     flags: DoenetMLFlags;
     baseId: string;
     maxAttemptsAllowed: number;
@@ -44,9 +18,8 @@ export function Activity({
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
     answerResponseCountsByItem?: Record<string, number>[];
-    state: ActivityState;
     doenetStates: unknown[];
-    loadedStateNum: number;
+    stateVersion: number;
     reportScoreAndStateCallback: (args: unknown) => void;
     checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
@@ -59,105 +32,47 @@ export function Activity({
     reportVisibility?: boolean;
     reportVisibilityCallback: (id: string, isVisible: boolean) => void;
     itemAttemptNumbers: number[];
-    itemSequence: string[];
+    itemIndexById: ReadonlyMap<string, number>;
     itemWord: string;
-}) {
+};
+
+export const Activity = memo(function Activity({
+    state,
+    ...props
+}: ActivityCommonProps & { state: ActivityState }) {
     switch (state.type) {
         case "singleDoc": {
+            // Extract this item's slice of the per-item arrays so the leaf's
+            // props only change when *its* data changes: the arrays get a
+            // fresh identity on every report from any document, which would
+            // otherwise defeat SingleDocActivity's memo for all N items.
+            const {
+                doenetStates,
+                itemAttemptNumbers,
+                answerResponseCountsByItem = [],
+                itemIndexById,
+                ...leafProps
+            } = props;
+            const itemIdx = itemIndexById.get(state.id) ?? -1;
             return (
                 <SingleDocActivity
-                    flags={flags}
-                    baseId={baseId}
-                    maxAttemptsAllowed={maxAttemptsAllowed}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    doenetViewerUrl={doenetViewerUrl}
-                    fetchExternalDoenetML={fetchExternalDoenetML}
-                    darkMode={darkMode}
-                    showAnswerResponseMenu={showAnswerResponseMenu}
-                    answerResponseCountsByItem={answerResponseCountsByItem}
+                    {...leafProps}
                     state={state}
-                    doenetStates={doenetStates}
-                    loadedStateNum={loadedStateNum}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    checkRender={checkRender}
-                    checkHidden={checkHidden}
-                    allowItemAttemptButtons={allowItemAttemptButtons}
-                    generateNewItemAttempt={generateNewItemAttempt}
-                    hasRenderedCallback={hasRenderedCallback}
-                    reportVisibility={reportVisibility}
-                    reportVisibilityCallback={reportVisibilityCallback}
-                    itemAttemptNumbers={itemAttemptNumbers}
-                    itemSequence={itemSequence}
-                    itemWord={itemWord}
+                    doenetState={
+                        state.doenetStateIdx === null
+                            ? null
+                            : (doenetStates[state.doenetStateIdx] ?? null)
+                    }
+                    itemAttemptNumber={itemAttemptNumbers[itemIdx]}
+                    answerResponseCounts={answerResponseCountsByItem[itemIdx]}
                 />
             );
         }
         case "select": {
-            return (
-                <SelectActivity
-                    flags={flags}
-                    baseId={baseId}
-                    maxAttemptsAllowed={maxAttemptsAllowed}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    doenetViewerUrl={doenetViewerUrl}
-                    fetchExternalDoenetML={fetchExternalDoenetML}
-                    darkMode={darkMode}
-                    showAnswerResponseMenu={showAnswerResponseMenu}
-                    answerResponseCountsByItem={answerResponseCountsByItem}
-                    state={state}
-                    doenetStates={doenetStates}
-                    loadedStateNum={loadedStateNum}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    checkRender={checkRender}
-                    checkHidden={checkHidden}
-                    allowItemAttemptButtons={allowItemAttemptButtons}
-                    generateNewItemAttempt={generateNewItemAttempt}
-                    hasRenderedCallback={hasRenderedCallback}
-                    reportVisibility={reportVisibility}
-                    reportVisibilityCallback={reportVisibilityCallback}
-                    itemAttemptNumbers={itemAttemptNumbers}
-                    itemSequence={itemSequence}
-                    itemWord={itemWord}
-                />
-            );
+            return <SelectActivity {...props} state={state} />;
         }
         case "sequence": {
-            return (
-                <SequenceActivity
-                    flags={flags}
-                    baseId={baseId}
-                    maxAttemptsAllowed={maxAttemptsAllowed}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    doenetViewerUrl={doenetViewerUrl}
-                    fetchExternalDoenetML={fetchExternalDoenetML}
-                    darkMode={darkMode}
-                    showAnswerResponseMenu={showAnswerResponseMenu}
-                    answerResponseCountsByItem={answerResponseCountsByItem}
-                    state={state}
-                    doenetStates={doenetStates}
-                    loadedStateNum={loadedStateNum}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    checkRender={checkRender}
-                    checkHidden={checkHidden}
-                    allowItemAttemptButtons={allowItemAttemptButtons}
-                    generateNewItemAttempt={generateNewItemAttempt}
-                    hasRenderedCallback={hasRenderedCallback}
-                    reportVisibility={reportVisibility}
-                    reportVisibilityCallback={reportVisibilityCallback}
-                    itemAttemptNumbers={itemAttemptNumbers}
-                    itemSequence={itemSequence}
-                    itemWord={itemWord}
-                />
-            );
+            return <SequenceActivity {...props} state={state} />;
         }
     }
-}
+});

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -1,108 +1,22 @@
-import { ReactElement } from "react";
-import type { DoenetMLFlags } from "../types";
+import { memo, ReactElement } from "react";
+import { Activity, ActivityCommonProps } from "./Activity";
 import { SelectState } from "./selectState";
-import { Activity } from "./Activity";
-import { ActivityState } from "./activityState";
 
-export function SelectActivity({
-    flags,
-    baseId,
-    maxAttemptsAllowed,
-    forceDisable = false,
-    forceShowCorrectness = false,
-    forceShowSolution = false,
-    forceUnsuppressCheckwork = false,
-    doenetViewerUrl,
-    fetchExternalDoenetML,
-    darkMode = "light",
-    showAnswerResponseMenu = false,
-    answerResponseCountsByItem = [],
+export const SelectActivity = memo(function SelectActivity({
     state,
-    doenetStates,
-    loadedStateNum,
-    reportScoreAndStateCallback,
-    checkRender,
-    checkHidden,
-    allowItemAttemptButtons = false,
-    generateNewItemAttempt,
-    hasRenderedCallback,
-    reportVisibility = false,
-    reportVisibilityCallback,
-    itemAttemptNumbers,
-    itemSequence,
-    itemWord,
-}: {
-    flags: DoenetMLFlags;
-    baseId: string;
-    maxAttemptsAllowed: number;
-    forceDisable?: boolean;
-    forceShowCorrectness?: boolean;
-    forceShowSolution?: boolean;
-    forceUnsuppressCheckwork?: boolean;
-    doenetViewerUrl?: string;
-    fetchExternalDoenetML?: (arg: string) => Promise<string>;
-    darkMode?: "dark" | "light";
-    showAnswerResponseMenu?: boolean;
-    answerResponseCountsByItem?: Record<string, number>[];
-    state: SelectState;
-    doenetStates: unknown[];
-    loadedStateNum: number;
-    reportScoreAndStateCallback: (args: unknown) => void;
-    checkRender: (state: ActivityState) => boolean;
-    checkHidden: (state: ActivityState) => boolean;
-    allowItemAttemptButtons?: boolean;
-    generateNewItemAttempt?: (
-        id: string,
-        initialQuestionCounter: number,
-    ) => void;
-    hasRenderedCallback: (id: string) => void;
-    reportVisibility?: boolean;
-    reportVisibilityCallback: (id: string, isVisible: boolean) => void;
-    itemAttemptNumbers: number[];
-    itemSequence: string[];
-    itemWord: string;
-}) {
+    ...props
+}: ActivityCommonProps & { state: SelectState }) {
     const selectedActivities: ReactElement[] = [];
-    const selectedIds: string[] = [];
 
     for (const activity of state.selectedChildren) {
         selectedActivities.push(
-            <Activity
-                key={activity.id}
-                state={activity}
-                doenetStates={doenetStates}
-                loadedStateNum={loadedStateNum}
-                flags={flags}
-                baseId={baseId}
-                maxAttemptsAllowed={maxAttemptsAllowed}
-                forceDisable={forceDisable}
-                forceShowCorrectness={forceShowCorrectness}
-                forceShowSolution={forceShowSolution}
-                forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                doenetViewerUrl={doenetViewerUrl}
-                fetchExternalDoenetML={fetchExternalDoenetML}
-                darkMode={darkMode}
-                showAnswerResponseMenu={showAnswerResponseMenu}
-                answerResponseCountsByItem={answerResponseCountsByItem}
-                reportScoreAndStateCallback={reportScoreAndStateCallback}
-                checkRender={checkRender}
-                checkHidden={checkHidden}
-                allowItemAttemptButtons={allowItemAttemptButtons}
-                generateNewItemAttempt={generateNewItemAttempt}
-                hasRenderedCallback={hasRenderedCallback}
-                reportVisibility={reportVisibility}
-                reportVisibilityCallback={reportVisibilityCallback}
-                itemAttemptNumbers={itemAttemptNumbers}
-                itemSequence={itemSequence}
-                itemWord={itemWord}
-            />,
+            <Activity key={activity.id} {...props} state={activity} />,
         );
-        selectedIds.push(activity.id);
     }
 
     return (
-        <div key={state.attemptNumber} hidden={!checkRender(state)}>
+        <div key={state.attemptNumber} hidden={!props.checkRender(state)}>
             <div>{selectedActivities}</div>
         </div>
     );
-}
+});

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -1,106 +1,22 @@
-import { ReactElement } from "react";
-import type { DoenetMLFlags } from "../types";
-import { Activity } from "./Activity";
+import { memo, ReactElement } from "react";
+import { Activity, ActivityCommonProps } from "./Activity";
 import { SequenceState } from "./sequenceState";
-import { ActivityState } from "./activityState";
 
-export function SequenceActivity({
-    flags,
-    baseId,
-    maxAttemptsAllowed,
-    forceDisable = false,
-    forceShowCorrectness = false,
-    forceShowSolution = false,
-    forceUnsuppressCheckwork = false,
-    doenetViewerUrl,
-    fetchExternalDoenetML,
-    darkMode = "light",
-    showAnswerResponseMenu = false,
-    answerResponseCountsByItem = [],
+export const SequenceActivity = memo(function SequenceActivity({
     state,
-    doenetStates,
-    loadedStateNum,
-    reportScoreAndStateCallback,
-    checkRender,
-    checkHidden,
-    allowItemAttemptButtons = false,
-    generateNewItemAttempt,
-    hasRenderedCallback,
-    reportVisibility = false,
-    reportVisibilityCallback,
-    itemAttemptNumbers,
-    itemSequence,
-    itemWord,
-}: {
-    flags: DoenetMLFlags;
-    baseId: string;
-    maxAttemptsAllowed: number;
-    forceDisable?: boolean;
-    forceShowCorrectness?: boolean;
-    forceShowSolution?: boolean;
-    forceUnsuppressCheckwork?: boolean;
-    doenetViewerUrl?: string;
-    fetchExternalDoenetML?: (arg: string) => Promise<string>;
-    darkMode?: "dark" | "light";
-    showAnswerResponseMenu?: boolean;
-    state: SequenceState;
-    answerResponseCountsByItem?: Record<string, number>[];
-    doenetStates: unknown[];
-    loadedStateNum: number;
-    reportScoreAndStateCallback: (args: unknown) => void;
-    checkRender: (state: ActivityState) => boolean;
-    checkHidden: (state: ActivityState) => boolean;
-    allowItemAttemptButtons?: boolean;
-    generateNewItemAttempt?: (
-        id: string,
-        initialQuestionCounter: number,
-    ) => void;
-    hasRenderedCallback: (id: string) => void;
-    reportVisibility?: boolean;
-    reportVisibilityCallback: (id: string, isVisible: boolean) => void;
-    itemAttemptNumbers: number[];
-    itemSequence: string[];
-    itemWord: string;
-}) {
+    ...props
+}: ActivityCommonProps & { state: SequenceState }) {
     const activityList: ReactElement[] = [];
 
     for (const activity of state.orderedChildren) {
         activityList.push(
-            <Activity
-                key={activity.id}
-                state={activity}
-                doenetStates={doenetStates}
-                loadedStateNum={loadedStateNum}
-                flags={flags}
-                baseId={baseId}
-                maxAttemptsAllowed={maxAttemptsAllowed}
-                forceDisable={forceDisable}
-                forceShowCorrectness={forceShowCorrectness}
-                forceShowSolution={forceShowSolution}
-                forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                doenetViewerUrl={doenetViewerUrl}
-                fetchExternalDoenetML={fetchExternalDoenetML}
-                darkMode={darkMode}
-                showAnswerResponseMenu={showAnswerResponseMenu}
-                answerResponseCountsByItem={answerResponseCountsByItem}
-                reportScoreAndStateCallback={reportScoreAndStateCallback}
-                checkRender={checkRender}
-                checkHidden={checkHidden}
-                allowItemAttemptButtons={allowItemAttemptButtons}
-                generateNewItemAttempt={generateNewItemAttempt}
-                hasRenderedCallback={hasRenderedCallback}
-                reportVisibility={reportVisibility}
-                reportVisibilityCallback={reportVisibilityCallback}
-                itemAttemptNumbers={itemAttemptNumbers}
-                itemSequence={itemSequence}
-                itemWord={itemWord}
-            />,
+            <Activity key={activity.id} {...props} state={activity} />,
         );
     }
 
     return (
-        <div hidden={!checkRender(state)} key={state.attemptNumber}>
+        <div hidden={!props.checkRender(state)} key={state.attemptNumber}>
             {activityList}
         </div>
     );
-}
+});

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -1,10 +1,23 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { DoenetMLFlags } from "../types";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { DoenetViewer } from "@doenet/doenetml-iframe";
 import { SingleDocState } from "./singleDocState";
-import { ActivityState } from "./activityState";
+import type { ActivityCommonProps } from "./Activity";
 
-export function SingleDocActivity({
+type SingleDocActivityProps = Omit<
+    ActivityCommonProps,
+    | "doenetStates"
+    | "itemAttemptNumbers"
+    | "answerResponseCountsByItem"
+    | "itemIndexById"
+> & {
+    state: SingleDocState;
+    /** This item's saved Doenet state (its slice of `doenetStates`). */
+    doenetState: unknown;
+    itemAttemptNumber: number;
+    answerResponseCounts?: Record<string, number>;
+};
+
+export const SingleDocActivity = memo(function SingleDocActivity({
     flags,
     baseId,
     maxAttemptsAllowed,
@@ -16,10 +29,10 @@ export function SingleDocActivity({
     fetchExternalDoenetML,
     darkMode = "light",
     showAnswerResponseMenu = false,
-    answerResponseCountsByItem = [],
+    answerResponseCounts,
     state,
-    doenetStates,
-    loadedStateNum,
+    doenetState,
+    stateVersion,
     reportScoreAndStateCallback,
     checkRender,
     checkHidden,
@@ -28,55 +41,19 @@ export function SingleDocActivity({
     hasRenderedCallback,
     reportVisibility = false,
     reportVisibilityCallback,
-    itemAttemptNumbers,
-    itemSequence,
+    itemAttemptNumber,
     itemWord,
-}: {
-    flags: DoenetMLFlags;
-    baseId: string;
-    maxAttemptsAllowed: number;
-    forceDisable?: boolean;
-    forceShowCorrectness?: boolean;
-    forceShowSolution?: boolean;
-    forceUnsuppressCheckwork?: boolean;
-    doenetViewerUrl?: string;
-    fetchExternalDoenetML?: (arg: string) => Promise<string>;
-    darkMode?: "dark" | "light";
-    showAnswerResponseMenu?: boolean;
-    answerResponseCountsByItem?: Record<string, number>[];
-    state: SingleDocState;
-    doenetStates: unknown[];
-    loadedStateNum: number;
-    reportScoreAndStateCallback: (args: unknown) => void;
-    checkRender: (state: ActivityState) => boolean;
-    checkHidden: (state: ActivityState) => boolean;
-    allowItemAttemptButtons?: boolean;
-    generateNewItemAttempt?: (
-        id: string,
-        initialQuestionCounter: number,
-    ) => void;
-    hasRenderedCallback: (id: string) => void;
-    reportVisibility?: boolean;
-    reportVisibilityCallback: (id: string, isVisible: boolean) => void;
-    itemAttemptNumbers: number[];
-    itemSequence: string[];
-    itemWord: string;
-}) {
+}: SingleDocActivityProps) {
     const [rendered, setRendered] = useState(false);
 
     const [attemptNumber, setAttemptNumber] = useState(state.attemptNumber);
-    const [loadedStateNumUsed, setLoadedStateNumUsed] = useState(0);
+    const [stateVersionUsed, setStateVersionUsed] = useState(stateVersion);
     const [initialDoenetState, setInitialDoenetState] = useState<Record<
         string,
         unknown
     > | null>(
-        (state.doenetStateIdx === null
-            ? null
-            : (doenetStates[state.doenetStateIdx] ?? null)) as Record<
-            string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            any
-        > | null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (doenetState ?? null) as Record<string, any> | null,
     );
 
     const [requestedVariantIndex, setRequestedVariantIndex] = useState(
@@ -84,13 +61,6 @@ export function SingleDocActivity({
     );
 
     const ref = useRef<HTMLDivElement>(null);
-
-    const itemIdx = useMemo(
-        () => itemSequence.indexOf(state.id),
-        [itemSequence, state.id],
-    );
-
-    const itemAttemptNumber = itemAttemptNumbers[itemIdx];
 
     useEffect(() => {
         if (reportVisibility && ref.current) {
@@ -109,34 +79,33 @@ export function SingleDocActivity({
         }
     }, [reportVisibility, ref, reportVisibilityCallback, state.id]);
 
-    // Note: given the way the `<DoenetViewer>` iframe is set up, any changes in props
-    // will reinitialize the activity. Hence, we make sure that no props change
-    // unless the attempt number has changed.
+    // The initial Doenet state is deliberately *frozen*: it seeds the viewer
+    // and must not follow every subsequent report (the viewer owns the live
+    // state). It is re-read only when the item gets a new attempt or the
+    // whole activity's state is externally (re)loaded (`stateVersion`).
     if (
         state.attemptNumber !== attemptNumber ||
-        loadedStateNumUsed !== loadedStateNum
+        stateVersionUsed !== stateVersion
     ) {
         setAttemptNumber(state.attemptNumber);
-        setLoadedStateNumUsed(loadedStateNum);
+        setStateVersionUsed(stateVersion);
 
         setInitialDoenetState(
-            (state.doenetStateIdx === null
-                ? null
-                : (doenetStates[state.doenetStateIdx] ?? null)) as Record<
-                string,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                any
-            > | null,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (doenetState ?? null) as Record<string, any> | null,
         );
 
         setRequestedVariantIndex(state.currentVariant);
     }
 
-    const initialCounters = {
-        question: state.initialQuestionCounter,
-        problem: state.initialQuestionCounter,
-        exercise: state.initialQuestionCounter,
-    };
+    const initialCounters = useMemo(
+        () => ({
+            question: state.initialQuestionCounter,
+            problem: state.initialQuestionCounter,
+            exercise: state.initialQuestionCounter,
+        }),
+        [state.initialQuestionCounter],
+    );
 
     const source = state.source;
 
@@ -157,7 +126,12 @@ export function SingleDocActivity({
         <div ref={ref}>
             <div hidden={!render || hidden} style={{ minHeight: "100px" }}>
                 <DoenetViewer
-                    key={state.attemptNumber}
+                    // `initialState` is seed-only for the viewer, so applying
+                    // a re-read one (new item attempt, or externally loaded
+                    // state — which may not change the attempt number)
+                    // requires a remount. Built from the *frozen* values so
+                    // the key and the seed always change in the same commit.
+                    key={`${attemptNumber.toString()}-${stateVersionUsed.toString()}`}
                     doenetML={source.doenetML}
                     doenetmlVersion={source.version}
                     render={render}
@@ -173,7 +147,7 @@ export function SingleDocActivity({
                     fetchExternalDoenetML={fetchExternalDoenetML}
                     darkMode={darkMode}
                     showAnswerResponseMenu={showAnswerResponseMenu}
-                    answerResponseCounts={answerResponseCountsByItem[itemIdx]}
+                    answerResponseCounts={answerResponseCounts}
                     addVirtualKeyboard={false}
                     initialState={initialDoenetState}
                     initializeCounters={initialCounters}
@@ -215,4 +189,4 @@ export function SingleDocActivity({
             </div>
         </div>
     );
-}
+});

--- a/src/Activity/activityState.ts
+++ b/src/Activity/activityState.ts
@@ -55,7 +55,30 @@ export type ActivityAndDoenetState = {
     activityState: ActivityState;
     doenetStates: unknown[];
     itemAttemptNumbers: number[];
+    /**
+     * Bumped whenever the whole activity's state is (re)initialized or
+     * replaced from outside — a new activity attempt, loaded saved state —
+     * so items know to re-read their initial Doenet state. (Per-item
+     * attempts are covered by the item's own `attemptNumber`.)
+     */
+    stateVersion: number;
+    /**
+     * Message of the error that interrupted the last attempt generation,
+     * or `null` when healthy. Kept in reducer state (rather than component
+     * state set from an effect) so it self-clears on the next successful
+     * action.
+     */
+    errMsg: string | null;
 };
+
+/**
+ * The core fields of {@link ActivityAndDoenetState} that callers supply;
+ * the reducer owns the bookkeeping fields (`stateVersion`, `errMsg`).
+ */
+export type ActivityAndDoenetStateCore = Omit<
+    ActivityAndDoenetState,
+    "stateVersion" | "errMsg"
+>;
 
 /**
  * The current state of an activity, where references to the source have been eliminated.
@@ -91,21 +114,6 @@ export function isActivitySource(obj: unknown): obj is ActivitySource {
 
 export function isActivityState(obj: unknown): obj is ActivityState {
     return isSingleDocState(obj) || isSelectState(obj) || isSequenceState(obj);
-}
-
-export function isActivityAndDoenetState(
-    obj: unknown,
-): obj is ActivityAndDoenetState {
-    const typedObj = obj as ActivityAndDoenetState;
-    return (
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        typedObj !== null &&
-        typeof typedObj === "object" &&
-        isActivityState(typedObj.activityState) &&
-        Array.isArray(typedObj.doenetStates) &&
-        Array.isArray(typedObj.itemAttemptNumbers) &&
-        typedObj.itemAttemptNumbers.every((x) => Number.isInteger(x) && x > 0)
-    );
 }
 
 export function isActivityStateNoSource(
@@ -213,7 +221,13 @@ export function initializeActivityAndDoenetState({
 
     const numItems = getNumItems(source);
     const itemAttemptNumbers = Array<number>(numItems).fill(1);
-    return { activityState, doenetStates: [], itemAttemptNumbers };
+    return {
+        activityState,
+        doenetStates: [],
+        itemAttemptNumbers,
+        stateVersion: 1,
+        errMsg: null,
+    };
 }
 
 /**

--- a/src/Activity/activityStateReducer.ts
+++ b/src/Activity/activityStateReducer.ts
@@ -6,11 +6,13 @@ import {
 } from "../types";
 import {
     ActivityAndDoenetState,
+    ActivityAndDoenetStateCore,
     ActivitySource,
     extractActivityItemCredit,
     gatherStates,
     generateNewActivityAttempt,
     generateNewSingleDocSubAttempt,
+    getItemSequence,
     getNumItems,
     initializeActivityState,
     propagateStateChangeToRoot,
@@ -26,7 +28,7 @@ type InitializeStateAction = {
 
 type SetStateAction = {
     type: "set";
-    state: ActivityAndDoenetState;
+    state: ActivityAndDoenetStateCore;
     allowSaveState: boolean;
     baseId: string;
 };
@@ -44,8 +46,6 @@ type GenerateActivityAttemptAction = {
 type GenerateSingleDocSubAttemptAction = {
     type: "generateSingleDocSubActivityAttempt";
     docId: string;
-    doenetStateIdx: number;
-    itemSequence: string[];
     numActivityVariants: ActivityVariantRecord;
     initialQuestionCounter: number;
     allowSaveState: boolean;
@@ -57,8 +57,6 @@ type UpdateSingleDocStateAction = {
     type: "updateSingleState";
     docId: string;
     doenetState: unknown;
-    doenetStateIdx: number;
-    itemSequence: string[];
     creditAchieved: number;
     allowSaveState: boolean;
     baseId: string;
@@ -89,6 +87,8 @@ export function activityDoenetStateReducer(
                 }),
                 doenetStates: [],
                 itemAttemptNumbers: Array<number>(numItems).fill(1),
+                stateVersion: state.stateVersion + 1,
+                errMsg: null,
             };
         }
         case "set": {
@@ -105,15 +105,30 @@ export function activityDoenetStateReducer(
                 };
                 window.postMessage(message);
             }
-            return action.state;
+            return {
+                ...action.state,
+                stateVersion: state.stateVersion + 1,
+                errMsg: null,
+            };
         }
         case "generateNewActivityAttempt": {
-            const { state: newActivityState } = generateNewActivityAttempt({
-                state: activityState,
-                numActivityVariants: action.numActivityVariants,
-                initialQuestionCounter: action.initialQuestionCounter,
-                parentAttempt: 1,
-            });
+            let newActivityState;
+            try {
+                ({ state: newActivityState } = generateNewActivityAttempt({
+                    state: activityState,
+                    numActivityVariants: action.numActivityVariants,
+                    initialQuestionCounter: action.initialQuestionCounter,
+                    parentAttempt: 1,
+                }));
+            } catch (e) {
+                // Surface the failure through state rather than throwing:
+                // React runs reducers during render, where a throw would
+                // unmount the viewer via an error boundary instead of
+                // showing the error message — and a later successful action
+                // self-clears it.
+                const message = e instanceof Error ? e.message : "";
+                return { ...state, errMsg: `Error in activity: ${message}` };
+            }
 
             // reset all item attempt numbers to 1
             const newItemAttemptNumbers = state.itemAttemptNumbers.map(() => 1);
@@ -143,6 +158,8 @@ export function activityDoenetStateReducer(
                 activityState: newActivityState,
                 doenetStates: [],
                 itemAttemptNumbers: newItemAttemptNumbers,
+                stateVersion: state.stateVersion + 1,
+                errMsg: null,
             };
         }
 
@@ -153,20 +170,34 @@ export function activityDoenetStateReducer(
                 );
             }
 
-            const newActivityState = generateNewSingleDocSubAttempt({
-                singleDocId: action.docId,
-                state: activityState,
-                numActivityVariants: action.numActivityVariants,
-                initialQuestionCounter: action.initialQuestionCounter,
-            });
+            // The document's position in the item sequence is derived from
+            // the reducer's own state (callers used to pass it in, which
+            // required them to track the current sequence).
+            const doenetStateIdx = getItemSequence(activityState).indexOf(
+                action.docId,
+            );
+
+            let newActivityState;
+            try {
+                newActivityState = generateNewSingleDocSubAttempt({
+                    singleDocId: action.docId,
+                    state: activityState,
+                    numActivityVariants: action.numActivityVariants,
+                    initialQuestionCounter: action.initialQuestionCounter,
+                });
+            } catch (e) {
+                // Same treatment as generateNewActivityAttempt: surface
+                // through state instead of throwing out of the dispatch.
+                const message = e instanceof Error ? e.message : "";
+                return { ...state, errMsg: `Error in activity: ${message}` };
+            }
 
             const newDoenetMLStates = [...state.doenetStates];
-            newDoenetMLStates[action.doenetStateIdx] = null;
+            newDoenetMLStates[doenetStateIdx] = null;
 
             // increment the item attempt number corresponding to the document
-            const itemIdx = action.itemSequence.indexOf(action.docId);
             const newItemAttemptNumbers = [...state.itemAttemptNumbers];
-            newItemAttemptNumbers[itemIdx]++;
+            newItemAttemptNumbers[doenetStateIdx]++;
 
             if (action.allowSaveState) {
                 const itemScores = extractActivityItemCredit(newActivityState);
@@ -190,7 +221,7 @@ export function activityDoenetStateReducer(
                     },
                     score: newActivityState.creditAchieved,
                     item_scores: itemScores,
-                    new_doenet_state_idx: action.doenetStateIdx,
+                    new_doenet_state_idx: doenetStateIdx,
                     subject: "SPLICE.reportScoreAndState",
                     activity_id: action.baseId,
                     message_id: nanoid(),
@@ -205,17 +236,34 @@ export function activityDoenetStateReducer(
                 activityState: newActivityState,
                 doenetStates: newDoenetMLStates,
                 itemAttemptNumbers: newItemAttemptNumbers,
+                // Not a stateVersion bump: the remount is driven by the
+                // item's own attemptNumber.
+                stateVersion: state.stateVersion,
+                errMsg: null,
             };
         }
         case "updateSingleState": {
-            const newActivityDoenetState = updateSingleDocState(action, state);
+            // A report can arrive from a document that is no longer part of
+            // the activity — e.g. an in-flight save from a just-regenerated
+            // attempt, or after a select re-picked its children. Ignore it:
+            // recording it would corrupt another item's slot, and throwing
+            // would unmount the whole viewer via an error boundary.
+            const doenetStateIdx = getItemSequence(activityState).indexOf(
+                action.docId,
+            );
+            if (doenetStateIdx === -1) {
+                return state;
+            }
+
+            const newActivityDoenetState = updateSingleDocState(
+                action,
+                doenetStateIdx,
+                state,
+            );
 
             if (action.allowSaveState) {
                 const newActivityState = newActivityDoenetState.activityState;
                 const itemScores = extractActivityItemCredit(newActivityState);
-
-                const itemUpdated =
-                    action.itemSequence.indexOf(action.docId) + 1;
 
                 const message: ReportStateMessage = {
                     state: {
@@ -227,8 +275,8 @@ export function activityDoenetStateReducer(
                     },
                     score: newActivityState.creditAchieved,
                     item_scores: itemScores,
-                    item_updated: itemUpdated,
-                    new_doenet_state_idx: action.doenetStateIdx,
+                    item_updated: doenetStateIdx + 1,
+                    new_doenet_state_idx: doenetStateIdx,
                     subject: "SPLICE.reportScoreAndState",
                     activity_id: action.baseId,
                     message_id: nanoid(),
@@ -245,12 +293,13 @@ export function activityDoenetStateReducer(
 }
 
 /**
- * Update the latest attempt of the single doc activity `action.id` to `action.doenetState` and `action.creditAchieved`.
+ * Update the latest attempt of the single doc activity `action.docId` to `action.doenetState` and `action.creditAchieved`.
  * Propagate this change upward in the activity tree to the root activity,
  * obtaining the new overall activity state and credit achieved.
  */
 function updateSingleDocState(
     action: UpdateSingleDocStateAction,
+    doenetStateIdx: number,
     activityDoenetState: ActivityAndDoenetState,
 ): ActivityAndDoenetState {
     const allStates = gatherStates(activityDoenetState.activityState);
@@ -268,8 +317,8 @@ function updateSingleDocState(
     newSingleDocState.creditAchieved = action.creditAchieved;
 
     const doenetStates = [...activityDoenetState.doenetStates];
-    doenetStates[action.doenetStateIdx] = action.doenetState;
-    newSingleDocState.doenetStateIdx = action.doenetStateIdx;
+    doenetStates[doenetStateIdx] = action.doenetState;
+    newSingleDocState.doenetStateIdx = doenetStateIdx;
 
     const rootActivityState = propagateStateChangeToRoot({
         allStates,
@@ -280,5 +329,7 @@ function updateSingleDocState(
         activityState: rootActivityState,
         doenetStates,
         itemAttemptNumbers: activityDoenetState.itemAttemptNumbers,
+        stateVersion: activityDoenetState.stateVersion,
+        errMsg: null,
     };
 }

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { DoenetMLFlags, isSingleDocReportStateMessage } from "../types";
 import {
@@ -26,6 +25,7 @@ import {
 } from "../Activity/activityState";
 import { Activity } from "../Activity/Activity";
 import { activityDoenetStateReducer } from "../Activity/activityStateReducer";
+import { useContentStable } from "../utils/hooks";
 
 export function Viewer({
     source,
@@ -76,28 +76,33 @@ export function Viewer({
     showTitle?: boolean;
     itemWord?: string;
 }) {
-    const [errMsg, setErrMsg] = useState<string | null>(null);
-
     const initialPass = useRef(true);
 
-    const { numActivityVariants, sourceHash, numItems } = useMemo(() => {
-        try {
-            validateIds(source);
-            const docStructure = gatherDocumentStructure(source);
-            const sourceHash = createSourceHash(source);
-            const numItems = getNumItems(source);
-            return { ...docStructure, sourceHash, numItems };
-        } catch (e) {
-            const message = e instanceof Error ? e.message : "";
-            // eslint-disable-next-line react-hooks/set-state-in-render
-            setErrMsg(`Error in activity source: ${message}`);
-            return {
-                numActivityVariants: {},
-                sourceHash: "",
-                numItems: 0,
-            };
-        }
-    }, [source]);
+    // Source analysis. A source error is *derived* from the memo (not set
+    // into state), so a later valid `source` self-clears it.
+    const { numActivityVariants, sourceHash, numItems, sourceErrMsg } =
+        useMemo(() => {
+            try {
+                validateIds(source);
+                const docStructure = gatherDocumentStructure(source);
+                const sourceHash = createSourceHash(source);
+                const numItems = getNumItems(source);
+                return {
+                    ...docStructure,
+                    sourceHash,
+                    numItems,
+                    sourceErrMsg: null,
+                };
+            } catch (e) {
+                const message = e instanceof Error ? e.message : "";
+                return {
+                    numActivityVariants: {},
+                    sourceHash: "",
+                    numItems: 0,
+                    sourceErrMsg: `Error in activity source: ${message}`,
+                };
+            }
+        }, [source]);
 
     const [activityDoenetState, activityDoenetStateDispatch] = useReducer(
         activityDoenetStateReducer,
@@ -110,19 +115,43 @@ export function Viewer({
         initializeActivityAndDoenetState,
     );
 
-    // Used to make sure reload activity when load in new state
-    const [loadedStateNum, setLoadedStateNum] = useState(0);
-
     const activityState = activityDoenetState.activityState;
 
-    const itemSequence = getItemSequence(activityState);
+    // Identifies the state generation items were seeded from: bumped by the
+    // reducer when the whole activity re-initializes or loads saved state,
+    // telling items to re-read their initial Doenet state.
+    const stateVersion = activityDoenetState.stateVersion;
+
+    // A runtime (attempt-generation) error leaves the previous activity
+    // state untouched, so the activity stays rendered with an error banner
+    // above it — the student's work is preserved and "New attempt" offers a
+    // retry, which self-clears the error on success.
+    const runtimeErrMsg = activityDoenetState.errMsg;
+
+    // Content-stable: every reducer action (each score report included)
+    // rebuilds `activityState`, but the sequence of item ids rarely changes.
+    // Keeping the previous identity when the ids match lets everything
+    // derived from it (`itemIdsToRender`, `checkRender`, the memoized item
+    // subtrees) stay stable across reports.
+    const computedItemSequence = useMemo(
+        () => getItemSequence(activityState),
+        [activityState],
+    );
+    const itemSequence = useContentStable(
+        computedItemSequence,
+        JSON.stringify(computedItemSequence),
+    );
+
+    const itemIndexById = useMemo(
+        () => new Map(itemSequence.map((id, idx) => [id, idx])),
+        [itemSequence],
+    );
 
     // The index of the current item
     const [currentItemIdx, setCurrentItemIdx] = useState(0);
     const currentItemId = itemSequence[currentItemIdx];
 
     const [itemsRendered, setItemsRendered] = useState<string[]>([]);
-    const [itemsToRender, setItemsToRender] = useState<string[]>([]);
     const [itemsVisible, setItemsVisible] = useState<string[]>([]);
 
     const [newAttemptNum, setNewAttemptNum] = useState(0);
@@ -131,28 +160,64 @@ export function Viewer({
 
     const attemptNumber = activityState.attemptNumber;
 
-    function addItemToRender(id: string) {
-        if (!itemsToRender.includes(id)) {
-            setItemsToRender((was) => {
-                if (was.includes(id)) {
-                    return was;
+    // The items allowed to mount their viewer, *derived* from which items
+    // have finished rendering: everything already rendered plus (at most)
+    // one in-flight item — in paginated mode the current item, then a
+    // prefetch of the next and previous; in scroll mode the first visible
+    // unrendered item. Deriving (rather than accumulating in state) keeps
+    // the schedule consistent through attempt resets and item regeneration,
+    // which simply remove ids from `itemsRendered`.
+    const itemIdsToRender = useMemo(() => {
+        const toRender = new Set(itemsRendered);
+        if (paginate) {
+            const currentItemId = itemSequence[currentItemIdx];
+            toRender.add(currentItemId);
+            if (itemsRendered.includes(currentItemId)) {
+                const nextItemId = itemSequence[currentItemIdx + 1];
+                if (currentItemIdx < numItems - 1) {
+                    // prefetch the next item once the current one rendered
+                    toRender.add(nextItemId);
                 }
-                const obj = [...was];
-                obj.push(id);
-                return obj;
-            });
+                if (
+                    currentItemIdx > 0 &&
+                    (currentItemIdx >= numItems - 1 ||
+                        itemsRendered.includes(nextItemId))
+                ) {
+                    // then the previous item
+                    toRender.add(itemSequence[currentItemIdx - 1]);
+                }
+            }
+        } else {
+            const visibleSet = new Set(itemsVisible);
+            for (const id of itemSequence) {
+                // `toRender` still equals the rendered set here (nothing was
+                // added in this branch), so it doubles as the fast
+                // membership test.
+                if (!toRender.has(id) && visibleSet.has(id)) {
+                    toRender.add(id);
+                    break;
+                }
+            }
         }
-    }
+        return toRender;
+    }, [
+        paginate,
+        itemsRendered,
+        itemsVisible,
+        itemSequence,
+        currentItemIdx,
+        numItems,
+    ]);
 
     const checkRender = useCallback(
         (state: ActivityState) => {
             if (state.type === "singleDoc") {
-                return itemsToRender.includes(state.id);
+                return itemIdsToRender.has(state.id);
             } else {
                 return true;
             }
         },
-        [itemsToRender],
+        [itemIdsToRender],
     );
 
     const checkHidden = useCallback(
@@ -169,7 +234,7 @@ export function Viewer({
     useEffect(() => {
         if (initialPass.current) {
             initialPass.current = false;
-        } else {
+        } else if (sourceErrMsg === null) {
             activityDoenetStateDispatch({
                 type: "initialize",
                 source,
@@ -177,9 +242,22 @@ export function Viewer({
                 numActivityVariants,
             });
         }
-    }, [activityId, source, initialVariantIndex, numActivityVariants]);
+    }, [
+        activityId,
+        source,
+        initialVariantIndex,
+        numActivityVariants,
+        sourceErrMsg,
+    ]);
 
     useEffect(() => {
+        if (sourceErrMsg !== null) {
+            // An invalid source must not reach the reducer; when a valid
+            // source arrives, this effect re-runs (its inputs derive from
+            // `source`) and initializes normally.
+            return;
+        }
+
         const listenersAdded: ((event: MessageEvent) => void)[] = [];
 
         function requestLoadState() {
@@ -220,8 +298,6 @@ export function Viewer({
                                 allowSaveState: flags.allowSaveState,
                                 baseId: activityId,
                             });
-
-                            setLoadedStateNum((was) => was + 1);
                         }
                     }
 
@@ -233,21 +309,15 @@ export function Viewer({
             listenersAdded.push(loadStateListener);
         }
 
-        try {
-            activityDoenetStateDispatch({
-                type: "generateNewActivityAttempt",
-                numActivityVariants,
-                initialQuestionCounter: 1,
-                allowSaveState: flags.allowSaveState,
-                baseId: activityId,
-                sourceHash,
-                initialAttempt: true,
-            });
-            setLoadedStateNum((was) => was + 1);
-        } catch (e) {
-            const message = e instanceof Error ? e.message : "";
-            setErrMsg(`Error in activity: ${message}`);
-        }
+        activityDoenetStateDispatch({
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 1,
+            allowSaveState: flags.allowSaveState,
+            baseId: activityId,
+            sourceHash,
+            initialAttempt: true,
+        });
 
         if (flags.allowLoadState) {
             requestLoadState();
@@ -267,6 +337,7 @@ export function Viewer({
         source,
         numActivityVariants,
         sourceHash,
+        sourceErrMsg,
     ]);
 
     function clickNext() {
@@ -276,38 +347,39 @@ export function Viewer({
         setCurrentItemIdx((was) => Math.max(0, was - 1));
     }
 
-    function reportScoreAndStateCallback(msg: unknown) {
-        if (isSingleDocReportStateMessage(msg)) {
-            activityDoenetStateDispatch({
-                type: "updateSingleState",
-                docId: msg.docId,
-                doenetState: msg.state,
-                doenetStateIdx: itemSequence.indexOf(msg.docId),
-                itemSequence,
-                creditAchieved: msg.score,
-                allowSaveState: flags.allowSaveState,
-                baseId: activityId,
-                sourceHash,
-            });
-        }
-    }
+    const reportScoreAndStateCallback = useCallback(
+        (msg: unknown) => {
+            if (isSingleDocReportStateMessage(msg)) {
+                // The reducer derives the document's position (and ignores
+                // reports from documents no longer in the activity).
+                activityDoenetStateDispatch({
+                    type: "updateSingleState",
+                    docId: msg.docId,
+                    doenetState: msg.state,
+                    creditAchieved: msg.score,
+                    allowSaveState: flags.allowSaveState,
+                    baseId: activityId,
+                    sourceHash,
+                });
+            }
+        },
+        [flags.allowSaveState, activityId, sourceHash],
+    );
 
-    function generateNewItemAttemptPrompt(
-        id: string,
-        initialQuestionCounter: number,
-    ) {
-        newItemAttemptInfo.current = { id, initialQuestionCounter };
-        setNewAttemptNum((itemSequence.indexOf(id) ?? 0) + 1);
-        dialogRef.current?.showModal();
-    }
+    const generateNewItemAttemptPrompt = useCallback(
+        (id: string, initialQuestionCounter: number) => {
+            newItemAttemptInfo.current = { id, initialQuestionCounter };
+            setNewAttemptNum((itemIndexById.get(id) ?? 0) + 1);
+            dialogRef.current?.showModal();
+        },
+        [itemIndexById],
+    );
 
     function generateNewItemAttempt() {
         const { id, initialQuestionCounter } = newItemAttemptInfo.current;
         activityDoenetStateDispatch({
             type: "generateSingleDocSubActivityAttempt",
             docId: id,
-            doenetStateIdx: itemSequence.indexOf(id),
-            itemSequence,
             numActivityVariants,
             initialQuestionCounter,
             allowSaveState: flags.allowSaveState,
@@ -324,55 +396,33 @@ export function Viewer({
                 return arr;
             }
         });
-        setItemsToRender((was) => {
-            const idx = was.indexOf(id);
-            if (idx === -1) {
-                return was;
-            } else {
-                const arr = [...was];
-                arr.splice(idx, 1);
-                return arr;
-            }
-        });
     }
 
-    function hasRenderedCallback(id: string) {
-        setItemsRendered((was) => {
-            if (was.includes(id)) {
-                return was;
-            }
-            const obj = [...was];
-            obj.push(id);
-            return obj;
-        });
-    }
+    const hasRenderedCallback = useCallback((id: string) => {
+        setItemsRendered((was) => (was.includes(id) ? was : [...was, id]));
+    }, []);
 
-    function reportVisibilityCallback(id: string, isVisible: boolean) {
-        setItemsVisible((was) => {
-            if (isVisible) {
-                if (was.includes(id)) {
-                    return was;
+    const reportVisibilityCallback = useCallback(
+        (id: string, isVisible: boolean) => {
+            setItemsVisible((was) => {
+                if (isVisible) {
+                    return was.includes(id) ? was : [...was, id];
                 } else {
-                    const obj = [...was];
-                    obj.push(id);
-                    return obj;
-                }
-            } else {
-                const idx = was.indexOf(id);
-                if (idx === -1) {
-                    return was;
-                } else {
+                    const idx = was.indexOf(id);
+                    if (idx === -1) {
+                        return was;
+                    }
                     const obj = [...was];
                     obj.splice(idx, 1);
                     return obj;
                 }
-            }
-        });
-    }
+            });
+        },
+        [],
+    );
 
     function generateActivityAttempt() {
         setItemsRendered([]);
-        setItemsToRender([]);
         setCurrentItemIdx(0);
         activityDoenetStateDispatch({
             type: "generateNewActivityAttempt",
@@ -384,12 +434,15 @@ export function Viewer({
         });
     }
 
-    if (errMsg !== null) {
-        const errorIcon = (
-            <span style={{ fontSize: "1em", color: "#C1292E" }}>
-                <MdError />
-            </span>
-        );
+    const errorIcon = (
+        <span style={{ fontSize: "1em", color: "#C1292E" }}>
+            <MdError />
+        </span>
+    );
+
+    // Without a valid source there is nothing to render; the derived
+    // `sourceErrMsg` self-clears when a valid `source` prop arrives.
+    if (sourceErrMsg !== null) {
         return (
             <div
                 style={{
@@ -398,38 +451,9 @@ export function Viewer({
                     marginTop: "20px",
                 }}
             >
-                {errorIcon} {errMsg}
+                {errorIcon} {sourceErrMsg}
             </div>
         );
-    }
-
-    if (paginate) {
-        if (!itemsRendered.includes(currentItemId)) {
-            // the current item is always rendered
-            addItemToRender(currentItemId);
-        } else {
-            const nextItemId = itemSequence[currentItemIdx + 1];
-            if (
-                currentItemIdx < numItems - 1 &&
-                !itemsRendered.includes(nextItemId)
-            ) {
-                // render the next item if the current item is already rendered
-                addItemToRender(nextItemId);
-            } else {
-                const prevItemId = itemSequence[currentItemIdx - 1];
-                if (currentItemIdx > 0 && !itemsRendered.includes(prevItemId)) {
-                    // render the previous item if the current and next item are already rendered
-                    addItemToRender(prevItemId);
-                }
-            }
-        }
-    } else {
-        for (const id of itemSequence) {
-            if (!itemsRendered.includes(id) && itemsVisible.includes(id)) {
-                addItemToRender(id);
-                break;
-            }
-        }
     }
 
     const activityAttemptsLeft = Math.max(
@@ -577,6 +601,18 @@ export function Viewer({
                 </div>
             </div>
 
+            {runtimeErrMsg !== null ? (
+                <div
+                    style={{
+                        fontSize: "1.3em",
+                        marginLeft: "20px",
+                        marginTop: "20px",
+                    }}
+                    data-test="Activity Error"
+                >
+                    {errorIcon} {runtimeErrMsg}
+                </div>
+            ) : null}
             <div
                 hidden={itemsRendered.length > 0 || numItems === 0}
                 style={{ marginLeft: "20px", marginTop: "20px" }}
@@ -598,7 +634,7 @@ export function Viewer({
                 answerResponseCountsByItem={answerResponseCountsByItem}
                 state={activityState}
                 doenetStates={activityDoenetState.doenetStates}
-                loadedStateNum={loadedStateNum}
+                stateVersion={stateVersion}
                 reportScoreAndStateCallback={reportScoreAndStateCallback}
                 checkRender={checkRender}
                 checkHidden={checkHidden}
@@ -608,7 +644,7 @@ export function Viewer({
                 reportVisibility={!paginate}
                 reportVisibilityCallback={reportVisibilityCallback}
                 itemAttemptNumbers={activityDoenetState.itemAttemptNumbers}
-                itemSequence={itemSequence}
+                itemIndexById={itemIndexById}
                 itemWord={itemWord}
             />
         </div>

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -1,5 +1,5 @@
 import "./assignment-viewer.css";
-import { Component, ErrorInfo, ReactNode, useRef, useState } from "react";
+import { Component, ErrorInfo, ReactNode, useMemo, useState } from "react";
 import seedrandom from "seedrandom";
 import { Viewer } from "./Viewer/Viewer";
 import { DoenetMLFlags } from "./types";
@@ -25,15 +25,15 @@ const defaultFlags: DoenetMLFlags = {
 
 const rngClass = seedrandom.alea;
 
-type PropSet = {
-    source: string;
-    activityId?: string;
-    requestedVariantIndex?: number;
-};
+// A stable default identity: an inline `= {}` default would be a fresh
+// object every render, making the `flags` memo below recompute (and hand the
+// memoized Activity tree a fresh `flags` identity) whenever the consumer
+// omits the prop.
+const NO_FLAGS: DoenetMLFlagsSubset = {};
 
 export function ActivityViewer({
     source,
-    flags: specifiedFlags = {},
+    flags: specifiedFlags = NO_FLAGS,
     activityId = "a",
     userId = null,
     requestedVariantIndex,
@@ -82,43 +82,34 @@ export function ActivityViewer({
     showTitle?: boolean;
     itemWord?: string;
 }) {
-    // const [variants, setVariants] = useState({
-    //     index: 1,
-    //     numVariants: 1,
-    //     allPossibleVariants: ["a"],
-    // });
-
     const [initialVariantIndex, setInitialVariantIndex] = useState<
         number | null
     >(null);
 
     const resolvedTheme = useResolvedTheme(darkMode);
 
-    const thisPropSet: PropSet = {
-        source: JSON.stringify(source),
-        activityId,
-        requestedVariantIndex,
-    };
-    const lastPropSet = useRef<PropSet>({ source: "" });
+    // Serializing the source is how prop "sameness" is detected for
+    // consumers that pass a fresh `source` object each render; memoize it so
+    // the (potentially large) assignment is only serialized when the
+    // identity actually changes.
+    const propSetKey = useMemo(
+        () => JSON.stringify([source, activityId, requestedVariantIndex]),
+        [source, activityId, requestedVariantIndex],
+    );
+    const [lastPropSetKey, setLastPropSetKey] = useState<string | null>(null);
 
-    const flags: DoenetMLFlags = { ...defaultFlags, ...specifiedFlags };
+    const flags: DoenetMLFlags = useMemo(
+        () => ({ ...defaultFlags, ...specifiedFlags }),
+        [specifiedFlags],
+    );
 
     // Normalize variant index to an integer.
     // Generate a random variant index if the requested variant index is undefined.
-    // To preserve the generated variant index on rerender,
-    // regenerate only if one of the props in propSet has changed
-    let foundPropChange = false;
-    let key: keyof PropSet;
-    for (key in thisPropSet) {
-        // eslint-disable-next-line react-hooks/refs
-        if (thisPropSet[key] !== lastPropSet.current[key]) {
-            foundPropChange = true;
-        }
-    }
-    // eslint-disable-next-line react-hooks/refs
-    lastPropSet.current = thisPropSet;
-
-    if (foundPropChange) {
+    // To preserve the generated variant index on rerender, regenerate only
+    // when one of the identifying props changed (the sanctioned
+    // adjust-state-during-render pattern).
+    if (propSetKey !== lastPropSetKey) {
+        setLastPropSetKey(propSetKey);
         if (requestedVariantIndex === undefined) {
             const rng = rngClass(new Date().toString());
             setInitialVariantIndex(Math.floor(rng() * 1000000) + 1);
@@ -137,10 +128,7 @@ export function ActivityViewer({
 
     return (
         <ErrorBoundary>
-            <div
-                className="assignment-viewer-root"
-                data-theme={resolvedTheme}
-            >
+            <div className="assignment-viewer-root" data-theme={resolvedTheme}>
                 <Viewer
                     source={source}
                     flags={flags}

--- a/src/test/activityStateReducer.test.ts
+++ b/src/test/activityStateReducer.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, MockInstance, vi } from "vitest";
 import { SequenceSource } from "../Activity/sequenceState";
 import {
     ActivityAndDoenetState,
+    ActivityAndDoenetStateCore,
     createSourceHash,
     gatherDocumentStructure,
     initializeActivityState,
@@ -15,12 +16,112 @@ import seq2sel from "./testSources/seq2sel.json";
 import doc from "./testSources/doc.json";
 import seqShuf from "./testSources/seqShuf.json";
 import selMult2docs from "./testSources/selMult2docs.json";
+import selMult1docNoVariant from "./testSources/selMult1docNoVariant.json";
 import { SingleDocSource, SingleDocState } from "../Activity/singleDocState";
 import { SelectSource, SelectState } from "../Activity/selectState";
+
+/**
+ * Build a full reducer state from its core fields (the reducer owns the
+ * `stateVersion`/`errMsg` bookkeeping fields).
+ */
+function mkState(
+    core: ActivityAndDoenetStateCore &
+        Partial<Pick<ActivityAndDoenetState, "stateVersion" | "errMsg">>,
+): ActivityAndDoenetState {
+    return { stateVersion: 0, errMsg: null, ...core };
+}
 
 describe("Activity reducer tests", () => {
     afterEach(() => {
         vi.restoreAllMocks();
+    });
+
+    it("attempt-generation error lands in errMsg and self-clears on the next successful action", () => {
+        const source = selMult1docNoVariant as SelectSource;
+        const { numActivityVariants } = gatherDocumentStructure(source);
+        const sourceHash = createSourceHash(source);
+
+        const state0 = initializeActivityState({
+            source,
+            variant: 1,
+            parentId: null,
+            numActivityVariants,
+        });
+
+        const initial = mkState({
+            activityState: state0,
+            doenetStates: [],
+            itemAttemptNumbers: [1, 1, 1],
+        });
+
+        // This source cannot generate an attempt (selects more copies than
+        // available activities); the reducer captures the error instead of
+        // throwing (a throw during React's render-phase reducer run would
+        // unmount the viewer via an error boundary).
+        const errored = activityDoenetStateReducer(initial, {
+            type: "generateNewActivityAttempt",
+            numActivityVariants,
+            initialQuestionCounter: 1,
+            allowSaveState: false,
+            baseId: "err",
+            sourceHash,
+            initialAttempt: true,
+        });
+        expect(errored.errMsg).toContain("Error in activity:");
+        expect(errored.errMsg).toContain(
+            "larger than the number of available activities",
+        );
+        // The rest of the state is untouched.
+        expect(errored.activityState).eq(initial.activityState);
+        expect(errored.stateVersion).eq(0);
+
+        // A later successful action clears the error.
+        const docSource = doc as SingleDocSource;
+        const cleared = activityDoenetStateReducer(errored, {
+            type: "initialize",
+            source: docSource,
+            variantIndex: 5,
+            numActivityVariants:
+                gatherDocumentStructure(docSource).numActivityVariants,
+        });
+        expect(cleared.errMsg).eq(null);
+        expect(cleared.stateVersion).eq(1);
+    });
+
+    it("ignores a report from a document that is not in the activity", () => {
+        vi.stubGlobal("window", {
+            postMessage: vi.fn(() => null),
+        });
+        const spy = vi.spyOn(window, "postMessage");
+
+        const source = doc as SingleDocSource;
+        const { numActivityVariants } = gatherDocumentStructure(source);
+
+        const state = mkState({
+            activityState: initializeActivityState({
+                source,
+                variant: 5,
+                parentId: null,
+                numActivityVariants,
+            }),
+            doenetStates: [],
+            itemAttemptNumbers: [1],
+        });
+
+        // e.g. an in-flight save from a just-regenerated attempt, or a
+        // select that re-picked its children
+        const newState = activityDoenetStateReducer(state, {
+            type: "updateSingleState",
+            docId: "no-longer-present",
+            doenetState: { some: "state" },
+            creditAchieved: 1,
+            allowSaveState: true,
+            baseId: "stale",
+            sourceHash: createSourceHash(source),
+        });
+
+        expect(newState).eq(state);
+        expect(spy).toHaveBeenCalledTimes(0);
     });
 
     it("initialize", () => {
@@ -36,11 +137,11 @@ describe("Activity reducer tests", () => {
         const { numActivityVariants } = gatherDocumentStructure(source);
 
         const newState = activityDoenetStateReducer(
-            {
+            mkState({
                 activityState: state0,
                 doenetStates: [],
                 itemAttemptNumbers: [1],
-            },
+            }),
             {
                 type: "initialize",
                 source,
@@ -68,6 +169,8 @@ describe("Activity reducer tests", () => {
             activityState: expectedActivityState,
             doenetStates: [],
             itemAttemptNumbers: [1],
+            stateVersion: 1,
+            errMsg: null,
         });
     });
 
@@ -102,11 +205,11 @@ describe("Activity reducer tests", () => {
         };
 
         let newState = activityDoenetStateReducer(
-            {
+            mkState({
                 activityState: state0,
                 doenetStates: [],
                 itemAttemptNumbers: [1],
-            },
+            }),
             {
                 type: "set",
                 state,
@@ -115,11 +218,15 @@ describe("Activity reducer tests", () => {
             },
         );
 
-        expect(newState).eqls(state);
+        expect(newState).eqls(mkState({ ...state, stateVersion: 1 }));
         expect(spy).toHaveBeenCalledTimes(0);
 
         newState = activityDoenetStateReducer(
-            { activityState, doenetStates: [], itemAttemptNumbers: [1] },
+            mkState({
+                activityState,
+                doenetStates: [],
+                itemAttemptNumbers: [1],
+            }),
             {
                 type: "set",
                 state,
@@ -128,7 +235,7 @@ describe("Activity reducer tests", () => {
             },
         );
 
-        expect(newState).eqls(state);
+        expect(newState).eqls(mkState({ ...state, stateVersion: 1 }));
         expect(spy).toHaveBeenCalledTimes(1);
 
         expect(spy.mock.lastCall).eqls([
@@ -171,11 +278,11 @@ describe("Activity reducer tests", () => {
         state0.creditAchieved = 0.8;
 
         let state = activityDoenetStateReducer(
-            {
+            mkState({
                 activityState: state0,
                 doenetStates: [],
                 itemAttemptNumbers: [1],
-            },
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -205,11 +312,11 @@ describe("Activity reducer tests", () => {
 
         // repeat creation of first attempt, this time with `allowSaveState`
         state = activityDoenetStateReducer(
-            {
+            mkState({
                 activityState: state0,
                 doenetStates: [],
                 itemAttemptNumbers: [1],
-            },
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -299,7 +406,6 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
     });
 
@@ -321,11 +427,11 @@ describe("Activity reducer tests", () => {
         });
 
         let state = activityDoenetStateReducer(
-            {
+            mkState({
                 activityState: state0,
                 doenetStates: [],
                 itemAttemptNumbers: [1],
-            },
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -340,9 +446,7 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "updateSingleState",
             docId: "doc5",
-            doenetStateIdx: 0,
             doenetState: "DoenetML state 1",
-            itemSequence: ["doc5"],
             creditAchieved: 0.2,
             allowSaveState: true,
             baseId: "newId",
@@ -392,9 +496,8 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
 
         // decrease score
@@ -402,8 +505,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: "doc5",
             doenetState: "DoenetML state 2",
-            doenetStateIdx: 0,
-            itemSequence: ["doc5"],
             creditAchieved: 0.1,
             allowSaveState: true,
             baseId: "newId",
@@ -453,9 +554,8 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
 
         // increase score
@@ -463,8 +563,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: "doc5",
             doenetState: "DoenetML state 3",
-            doenetStateIdx: 0,
-            itemSequence: ["doc5"],
             creditAchieved: 0.3,
             allowSaveState: true,
             baseId: "newId",
@@ -514,9 +612,8 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
 
         // generate new attempt
@@ -565,7 +662,6 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
 
         // start attempt with low score
@@ -573,8 +669,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: "doc5",
             doenetState: "DoenetML state 4",
-            doenetStateIdx: 0,
-            itemSequence: ["doc5"],
             creditAchieved: 0.1,
             allowSaveState: true,
             baseId: "newId",
@@ -624,9 +718,8 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
 
         // increase score
@@ -634,8 +727,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: "doc5",
             doenetState: "DoenetML state 5",
-            doenetStateIdx: 0,
-            itemSequence: ["doc5"],
             creditAchieved: 0.5,
             allowSaveState: true,
             baseId: "newId",
@@ -685,9 +776,8 @@ describe("Activity reducer tests", () => {
             },
         ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
         expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
     });
 
@@ -804,11 +894,9 @@ describe("Activity reducer tests", () => {
         ]);
 
         if (!new_attempt) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
         }
         if (!new_attempt_for_item) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
         }
     }
@@ -834,11 +922,11 @@ describe("Activity reducer tests", () => {
         const itemAttemptNumbers = [1, 1, 1];
 
         let state = activityDoenetStateReducer(
-            {
+            mkState({
                 activityState: state0,
                 doenetStates: [],
                 itemAttemptNumbers,
-            },
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -869,8 +957,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -898,8 +984,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -926,8 +1010,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -982,8 +1064,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[2],
             doenetState: docStates[2],
-            doenetStateIdx: 2,
-            itemSequence: docIds,
             creditAchieved: docCredits[2],
             allowSaveState: true,
             baseId: "newId",
@@ -1028,7 +1108,11 @@ describe("Activity reducer tests", () => {
         const itemAttemptNumbers = [1, 1, 1];
 
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [], itemAttemptNumbers },
+            mkState({
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers,
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -1059,8 +1143,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1088,8 +1170,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1116,8 +1196,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1141,8 +1219,6 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             allowSaveState: true,
@@ -1177,8 +1253,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1206,8 +1280,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[2],
             doenetState: docStates[2],
-            doenetStateIdx: 2,
-            itemSequence: docIds,
             creditAchieved: docCredits[2],
             allowSaveState: true,
             baseId: "newId",
@@ -1235,8 +1307,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1261,8 +1331,6 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             allowSaveState: true,
@@ -1297,8 +1365,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1447,11 +1513,9 @@ describe("Activity reducer tests", () => {
         ]);
 
         if (!new_attempt) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
         }
         if (!new_attempt_for_item) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
         }
     }
@@ -1476,7 +1540,11 @@ describe("Activity reducer tests", () => {
 
         const itemAttemptNumbers = [1, 1];
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [], itemAttemptNumbers },
+            mkState({
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers,
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -1519,8 +1587,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1552,8 +1618,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1585,8 +1649,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1671,8 +1733,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1719,7 +1779,11 @@ describe("Activity reducer tests", () => {
         const itemAttemptNumbers = [1, 1];
 
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [], itemAttemptNumbers },
+            mkState({
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers,
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -1762,8 +1826,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -1795,8 +1857,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1828,8 +1888,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1857,8 +1915,6 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             allowSaveState: true,
@@ -1912,8 +1968,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1945,8 +1999,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -1974,8 +2026,6 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             allowSaveState: true,
@@ -2029,8 +2079,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -2170,11 +2218,9 @@ describe("Activity reducer tests", () => {
         ]);
 
         if (!new_attempt) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect("new_attempt" in spy.mock.lastCall![0]).eq(false);
         }
         if (!new_attempt_for_item) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect("new_attempt_for_item" in spy.mock.lastCall![0]).eq(false);
         }
     }
@@ -2200,7 +2246,11 @@ describe("Activity reducer tests", () => {
         const itemAttemptNumbers = [1, 1];
 
         let state = activityDoenetStateReducer(
-            { activityState: state0, doenetStates: [], itemAttemptNumbers },
+            mkState({
+                activityState: state0,
+                doenetStates: [],
+                itemAttemptNumbers,
+            }),
             {
                 type: "generateNewActivityAttempt",
                 numActivityVariants,
@@ -2232,8 +2282,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",
@@ -2261,8 +2309,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2290,8 +2336,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2316,8 +2360,6 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             allowSaveState: true,
@@ -2362,8 +2404,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2391,8 +2431,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[1],
             doenetState: docStates[1],
-            doenetStateIdx: 1,
-            itemSequence: docIds,
             creditAchieved: docCredits[1],
             allowSaveState: true,
             baseId: "newId",
@@ -2417,8 +2455,6 @@ describe("Activity reducer tests", () => {
         state = activityDoenetStateReducer(state, {
             type: "generateSingleDocSubActivityAttempt",
             docId: docIds[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             numActivityVariants,
             initialQuestionCounter: 0,
             allowSaveState: true,
@@ -2462,8 +2498,6 @@ describe("Activity reducer tests", () => {
             type: "updateSingleState",
             docId: docIds[0],
             doenetState: docStates[0],
-            doenetStateIdx: 0,
-            itemSequence: docIds,
             creditAchieved: docCredits[0],
             allowSaveState: true,
             baseId: "newId",

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+/**
+ * Keep the previous identity of a derived value when its content (as
+ * captured by `key`) is unchanged, so downstream memos and `React.memo`
+ * children are not invalidated by recomputations that produced equal
+ * content. The sanctioned adjust-state-during-render pattern: when the key
+ * changes, the new value is adopted (and returned for the current render).
+ */
+export function useContentStable<T>(value: T, key: string): T {
+    const [stable, setStable] = useState({ value, key });
+    if (stable.key !== key) {
+        setStable({ value, key });
+        return value;
+    }
+    return stable.value;
+}

--- a/test/cypress/component/ActivityViewer.errorRecovery.cy.tsx
+++ b/test/cypress/component/ActivityViewer.errorRecovery.cy.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { ActivityViewer } from "../../../src/activity-viewer";
+import { IFRAME_READY_TIMEOUT } from "./helpers";
+import type { ActivitySource } from "../../../src/Activity/activityState";
+
+// Issue #40: a source/runtime error must clear once the underlying problem
+// is fixed — updating the `source` prop from an invalid to a valid activity
+// on the SAME mounted component must leave the error screen and render the
+// activity. (Previously `errMsg` was set from inside a useMemo and never
+// reset, so the stale error persisted forever.)
+
+const VALID_SOURCE: ActivitySource = {
+    type: "singleDoc",
+    id: "test-doc",
+    doenetML: "<p>Recovered content</p>",
+    version: "0.7.4",
+    isDescription: false,
+    numVariants: 1,
+};
+
+// Duplicate ids: rejected by source validation (validateIds).
+const INVALID_SOURCE: ActivitySource = {
+    type: "sequence",
+    id: "dup",
+    title: "duplicated ids",
+    shuffle: false,
+    items: [
+        {
+            type: "singleDoc",
+            id: "dup",
+            doenetML: "<p>one</p>",
+            version: "0.7.4",
+            isDescription: false,
+            numVariants: 1,
+        },
+    ],
+};
+
+/**
+ * Assert the iframe rendered `text` as real content. The raw doenetML also
+ * sits in a `<script type="text/doenetml">` tag inside the iframe, so a
+ * plain `contain.text` on the body would match before (or without) any
+ * rendering — strip script tags first.
+ */
+function assertRenderedContent(text: string) {
+    cy.get("iframe")
+        .its("0.contentDocument.body", { timeout: IFRAME_READY_TIMEOUT })
+        .should((body: HTMLElement) => {
+            const clone = body.cloneNode(true) as HTMLElement;
+            clone.querySelectorAll("script").forEach((s) => {
+                s.remove();
+            });
+            expect(clone.textContent).to.contain(text);
+        });
+}
+
+function Harness() {
+    const [valid, setValid] = useState(true);
+    return (
+        <div>
+            <button
+                data-test="toggle-source"
+                onClick={() => {
+                    setValid(!valid);
+                }}
+            >
+                source: {valid ? "valid" : "invalid"}
+            </button>
+            <ActivityViewer
+                source={valid ? VALID_SOURCE : INVALID_SOURCE}
+                activityId="error-recovery"
+                addVirtualKeyboard={false}
+            />
+        </div>
+    );
+}
+
+describe("ActivityViewer — error state clears when the source is fixed", () => {
+    it("shows a source error and recovers when a valid source arrives on the same mount", () => {
+        cy.mount(<Harness />);
+
+        // Healthy at first.
+        assertRenderedContent("Recovered content");
+        cy.contains("Error in activity source").should("not.exist");
+
+        // Break the source: the error screen replaces the activity.
+        cy.get("[data-test=toggle-source]").click();
+        cy.contains("Error in activity source").should("exist");
+        cy.get("iframe").should("not.exist");
+
+        // Fix the source on the same mounted component: the error clears
+        // and the activity renders again.
+        cy.get("[data-test=toggle-source]").click();
+        cy.contains("Error in activity source").should("not.exist");
+        assertRenderedContent("Recovered content");
+    });
+});


### PR DESCRIPTION
Fixes #40. Fixes #41. Implements most of #38 and #34.

## Error state (#40)

- A **source error** is now derived from the source-analysis `useMemo` instead of being set into state from inside it — updating `source` from an invalid to a valid activity on the same mounted component clears the error and renders the activity (new cypress spec covers the repro).
- **Runtime attempt-generation errors** (whole-activity *and* per-item) are captured by the reducer instead of throwing — a throw during React's render-phase reducer run unmounts the viewer via an error boundary. They now render as a banner while the activity (whose state the failed action left untouched) stays mounted: no student work is lost, and "New attempt" offers a retry that self-clears the error on success.

## React Compiler (#41)

The `set-state-in-render` suppression that made the compiler bail on the whole `Viewer` component is gone, along with all three violations it masked:

- `loadedStateNum` became a reducer-owned `stateVersion` counter (no more setState-in-effect);
- `itemSequence` is memoized **content-stable** — every score report rebuilds the state tree without changing the id sequence, and keeping the previous identity keeps `itemIdsToRender`/`checkRender`/the memoized item subtrees stable across reports;
- the render-body `addItemToRender` scheduling was replaced by *deriving* the set of items allowed to render from `itemsRendered` plus the pagination/visibility rules (the accumulate-in-state version was redundant state).

`eslint .` passes with zero errors and zero react-hooks suppressions in the render path.

## Render hygiene (#38)

The Activity tree components are memoized with stable callbacks; per-item slices of `doenetStates` / `itemAttemptNumbers` / `answerResponseCountsByItem` are extracted at the Activity→SingleDoc boundary (index lookups via a `Map`), so a score report from one document no longer re-renders every item's subtree. `ActivityViewer` serializes `source` for prop-change detection only when its identity changes (was: every render), and `flags` defaults to a stable identity.

## Report-flow hardening (from review)

- The reducer derives a document's sequence position itself (callers no longer pass `itemSequence`/`doenetStateIdx`, which required tracking the current sequence in a ref with a stale window) and **ignores reports from documents no longer in the activity** — such a stale report (e.g. an in-flight save racing a new attempt) used to throw out of the reducer and unmount every item.
- The `DoenetViewer` key now includes the frozen state version: externally loaded state (`SPLICE.getState`) that doesn't change an item's attempt number previously updated only `initialState`, which the viewer treats as seed-only — the loaded work was silently ignored.

## Behavior note

The derived render schedule drops an *in-flight* (not-yet-initialized) prefetch item when the user navigates away before it finishes booting; it re-mounts when eligible again. Previously such items stayed scheduled forever. Items that finished rendering are unaffected.

## Tests

43 vitest (new: runtime-error capture + self-clearing; stale-report ignored) and 8 cypress component tests (new: error-recovery repro for #40) pass; `eslint .` and `vite build` clean. Worth a manual pass in the dev harness (pagination, attempt regeneration, load-state) given the thin automated coverage of the render flow noted in #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)