### PR TITLE
Windowed mounting by default: memory tracks the visible window, not assignment length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Cypress run artifacts
+cypress/screenshots/
+cypress/videos/

--- a/README.md
+++ b/README.md
@@ -34,3 +34,37 @@ and the page decides how to display it:
 To consolidate, normalize the documents' `version` fields in the assignment
 source. Saved student state survives such a change: it is keyed on a source
 hash that deliberately ignores `version`.
+
+## Windowed mounting
+
+Every item's viewer component is always mounted, but memory tracks what the
+student can see — the pagination window or viewport — instead of the
+assignment's length. The embedded viewers register with a page-wide
+_windowed mounting_ policy (`mountPolicy` from `@doenet/doenetml-iframe`):
+items only boot their iframe (a multi-MB bundle parse plus a core worker)
+when near the viewport or within the pagination window, simultaneous boots
+are capped, and at most `maxLiveViewers` stay live — the rest are **parked**:
+their state is flushed, their iframe is replaced by a placeholder, and they
+are restored (student's typed work intact) when the student returns to them.
+In paginated mode the current page and its neighbors are kept live, so page
+flips within the window stay instant.
+
+This is the default. Tune it with the `mountPolicy` prop (overrides for
+`maxLiveViewers`, `visibleMargin`, `parkDelayMs`, `flushTimeoutMs`,
+`maxConcurrentBoots`):
+
+```tsx
+<ActivityViewer
+    source={source}
+    flags={{ allowSaveState: true }}
+    mountPolicy={{ maxLiveViewers: 5 }}
+/>
+```
+
+Parking requires a persistence path (`flags.allowSaveState` or
+`flags.allowLocalState`) so no student work can be lost; without one,
+viewers still mount lazily but stay live once booted.
+
+To cut the per-document core cost further, `useSharedCoreWorker` serves all
+documents' cores from a shared worker pool instead of one dedicated ~100 MB
+worker per document (default off; see `@doenet/doenetml-iframe`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "file:../DoenetML3/packages/doenetml-iframe",
+                "@doenet/doenetml-iframe": "^0.7.20-dev.329",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "seedrandom": "^3.0.5"
             },
             "devDependencies": {
-                "@doenet/doenetml-iframe": "0.7.20-dev.329",
+                "@doenet/doenetml-iframe": "0.7.20-dev.332",
                 "@eslint/js": "^9.39.1",
                 "@types/object-hash": "^3.0.6",
                 "@types/react": "^19.2.7",
@@ -39,7 +39,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "^0.7.20-dev.329",
+                "@doenet/doenetml-iframe": "^0.7.20-dev.332",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }
@@ -335,9 +335,9 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.20-dev.329",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.329.tgz",
-            "integrity": "sha512-VpXeW7/pZyYfysdwFTRLIRVsz8JevM7CwX3oPtO+1F/FabQz3UmIOaqsTTBNw8Hjs43VU9GnxooCMMLhDXaZmA==",
+            "version": "0.7.20-dev.332",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.332.tgz",
+            "integrity": "sha512-V6/fa/ZOFfd3lFlaXabArMpMBlSv9xOfnHOEBfy3mRhizjwucriu2PxdV/GnynA/G6Y2Ayve3y7nK7PTGoaq/Q==",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "seedrandom": "^3.0.5"
             },
             "devDependencies": {
+                "@doenet/doenetml-iframe": "0.7.20-dev.329",
                 "@eslint/js": "^9.39.1",
                 "@types/object-hash": "^3.0.6",
                 "@types/react": "^19.2.7",
@@ -38,7 +39,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "^0.7.20-dev.326",
+                "@doenet/doenetml-iframe": "file:../DoenetML3/packages/doenetml-iframe",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }
@@ -334,11 +335,11 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.20-dev.326",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.326.tgz",
-            "integrity": "sha512-AVqNUorjP3Wo82Vh6NUZanecdIm62Bm8GA37jfguM7J+x/AAW8Y1oEPAkNFD34G5EISex1Sg/3XuZC1nzEiouQ==",
+            "version": "0.7.20-dev.329",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.329.tgz",
+            "integrity": "sha512-VpXeW7/pZyYfysdwFTRLIRVsz8JevM7CwX3oPtO+1F/FabQz3UmIOaqsTTBNw8Hjs43VU9GnxooCMMLhDXaZmA==",
+            "dev": true,
             "license": "AGPL-3.0-or-later",
-            "peer": true,
             "peerDependencies": {
                 "better-react-mathjax": "^3.0.0",
                 "react": "^19.2.3",
@@ -1070,23 +1071,25 @@
             }
         },
         "node_modules/@mathjax/mathjax-newcm-font": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.2.tgz",
-            "integrity": "sha512-lZHMjNP2XbABHA3kVn40rbse5ERUeMEmrGH03qLkCwxq4/5Z/eNLr0akw1MmQcqTwCbvkx1BFcmJ7RCfbRlw3Q==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.3.tgz",
+            "integrity": "sha512-gzAB3dFHilHX1l5x2xUqRL+1jDQt3Fyza1DkEMVXWC4E8SvsGdlgEza47HYi2WhVcgfkvf4zgUGzuhbq3Pjlew==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true
         },
         "node_modules/@mathjax/src": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@mathjax/src/-/src-4.1.2.tgz",
-            "integrity": "sha512-7z3mQCQu4YqC1XyO4hMRkNTO49+5ZN8VtvBYKx+aGIXuGrlUvEAQZzeN/gf3tqZuVU4AI2yf1nYrrL1+BrSxIQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@mathjax/src/-/src-4.1.3.tgz",
+            "integrity": "sha512-rIrWquuBSoJuoMBdC/1qD+AUHTorlccPicoVy6P2xbUgnuDBpCcpbHtOAsB8L3hdCHtNBg92lF8e3Fz+pkcQbw==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@mathjax/mathjax-newcm-font": "4.1.2",
+                "@mathjax/mathjax-newcm-font": "4.1.3",
                 "mhchemparser": "^4.2.1",
                 "mj-context-menu": "^1.0.0",
-                "speech-rule-engine": "5.0.0-rc.1"
+                "speech-rule-engine": "5.0.0-rc.4"
             }
         },
         "node_modules/@microsoft/api-extractor": {
@@ -2715,6 +2718,7 @@
             "version": "0.9.10",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
             "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -3160,6 +3164,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-3.0.1.tgz",
             "integrity": "sha512-NfDraTcTkL5mFTLID7VI1apbfIMcgStL2ON9PFsViEZyzQikkOlRJFJumAkvntqt3G5BN/vxcP3W1H4n6b5oag==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3577,6 +3582,7 @@
             "version": "14.0.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
             "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -4440,6 +4446,7 @@
             "version": "3.2.25",
             "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
             "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -4953,6 +4960,7 @@
             "version": "13.0.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
             "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true,
             "dependencies": {
@@ -4984,6 +4992,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -4991,9 +5000,10 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -5007,6 +5017,7 @@
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true,
             "dependencies": {
@@ -6393,6 +6404,7 @@
             "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
             "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
             "deprecated": "Version 4 replaces this package with the scoped package @mathjax/src",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -6406,6 +6418,7 @@
             "version": "13.1.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
             "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -6416,6 +6429,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
             "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true
         },
@@ -6423,6 +6437,7 @@
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.4.tgz",
             "integrity": "sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -6445,6 +6460,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
             "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true
         },
@@ -6521,6 +6537,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true,
             "engines": {
@@ -6531,6 +6548,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-1.0.0.tgz",
             "integrity": "sha512-OSgBFQRCVhrZwRa9lhqnKcJU92dd/YXgBjup0uyeuj9bOaVsf4myOyrjU4PfhYkdDk6AqVUTov7v5uFMvIbduA==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -6879,6 +6897,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true
         },
@@ -6933,6 +6952,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
             "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true,
             "dependencies": {
@@ -6947,9 +6967,10 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true,
             "engines": {
@@ -7413,6 +7434,7 @@
             "version": "6.1.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
             "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "peer": true,
             "dependencies": {
@@ -7837,9 +7859,10 @@
             }
         },
         "node_modules/speech-rule-engine": {
-            "version": "5.0.0-rc.1",
-            "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-5.0.0-rc.1.tgz",
-            "integrity": "sha512-WgxL1K0MXNXW7+4fn11B6rtJ+jZTnCQMkJ44yV3XmFDcpGBqFJrDEHouGuFryqB5hoG1ksE2zlss/m6KOWnbPA==",
+            "version": "5.0.0-rc.4",
+            "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-5.0.0-rc.4.tgz",
+            "integrity": "sha512-3dFcH2QtQNhtvUUc09TxoaEK4WG03B9Z57krFG9jocrKykKGu35BhIkWr0vgEAxZZomEWkeluff69y/EbYzP4Q==",
+            "dev": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -8825,6 +8848,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
             "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+            "dev": true,
             "license": "MIT",
             "peer": true
         },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "prettier:check": "prettier --check ."
     },
     "peerDependencies": {
-        "@doenet/doenetml-iframe": "^0.7.20-dev.326",
+        "@doenet/doenetml-iframe": "^0.7.20-dev.329",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
     },
@@ -49,6 +49,7 @@
         "seedrandom": "^3.0.5"
     },
     "devDependencies": {
+        "@doenet/doenetml-iframe": "0.7.20-dev.329",
         "@eslint/js": "^9.39.1",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "prettier:check": "prettier --check ."
     },
     "peerDependencies": {
-        "@doenet/doenetml-iframe": "^0.7.20-dev.329",
+        "@doenet/doenetml-iframe": "^0.7.20-dev.332",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
     },
@@ -49,7 +49,7 @@
         "seedrandom": "^3.0.5"
     },
     "devDependencies": {
-        "@doenet/doenetml-iframe": "0.7.20-dev.329",
+        "@doenet/doenetml-iframe": "0.7.20-dev.332",
         "@eslint/js": "^9.39.1",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.7",

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import type { MountPolicy } from "@doenet/doenetml-iframe";
 import { DoenetMLFlags } from "../types";
 import { ActivityState } from "./activityState";
 import { SelectActivity } from "./SelectActivity";
@@ -13,24 +14,32 @@ export type ActivityCommonProps = {
     forceShowCorrectness?: boolean;
     forceShowSolution?: boolean;
     forceUnsuppressCheckwork?: boolean;
-    doenetViewerUrl?: string;
+    standaloneUrl?: string;
+    cssUrl?: string;
+    doenetmlVersion?: string;
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
     answerResponseCountsByItem?: Record<string, number>[];
     doenetStates: unknown[];
     stateVersion: number;
+    /** The windowed mounting policy every item's viewer registers with. */
+    mountPolicy: MountPolicy;
+    useSharedCoreWorker?: boolean;
     reportScoreAndStateCallback: (args: unknown) => void;
-    checkRender: (state: ActivityState) => boolean;
     checkHidden: (state: ActivityState) => boolean;
+    /**
+     * Whether an item's viewer should stay booted even while hidden or
+     * off-screen (the paginator marks the current page and its neighbors
+     * so page flips are instant).
+     */
+    checkKeepLive: (state: ActivityState) => boolean;
     allowItemAttemptButtons?: boolean;
     generateNewItemAttempt?: (
         id: string,
         initialQuestionCounter: number,
     ) => void;
     hasRenderedCallback: (id: string) => void;
-    reportVisibility?: boolean;
-    reportVisibilityCallback: (id: string, isVisible: boolean) => void;
     itemAttemptNumbers: number[];
     itemIndexById: ReadonlyMap<string, number>;
     itemWord: string;

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -14,6 +14,10 @@ export type ActivityCommonProps = {
     forceShowCorrectness?: boolean;
     forceShowSolution?: boolean;
     forceUnsuppressCheckwork?: boolean;
+    /** URL the `<ref>` renderer uses to link to other Doenet activities. */
+    doenetViewerUrl?: string;
+    /** URL used to resolve `<image source="doenet:…">` media references. */
+    doenetMediaUrl?: string;
     standaloneUrl?: string;
     cssUrl?: string;
     doenetmlVersion?: string;

--- a/src/Activity/SelectActivity.tsx
+++ b/src/Activity/SelectActivity.tsx
@@ -15,7 +15,7 @@ export const SelectActivity = memo(function SelectActivity({
     }
 
     return (
-        <div key={state.attemptNumber} hidden={!props.checkRender(state)}>
+        <div key={state.attemptNumber}>
             <div>{selectedActivities}</div>
         </div>
     );

--- a/src/Activity/SequenceActivity.tsx
+++ b/src/Activity/SequenceActivity.tsx
@@ -14,9 +14,5 @@ export const SequenceActivity = memo(function SequenceActivity({
         );
     }
 
-    return (
-        <div hidden={!props.checkRender(state)} key={state.attemptNumber}>
-            {activityList}
-        </div>
-    );
+    return <div key={state.attemptNumber}>{activityList}</div>;
 });

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -25,6 +25,8 @@ export const SingleDocActivity = memo(function SingleDocActivity({
     forceShowCorrectness = false,
     forceShowSolution = false,
     forceUnsuppressCheckwork = false,
+    doenetViewerUrl,
+    doenetMediaUrl,
     standaloneUrl,
     cssUrl,
     doenetmlVersion,
@@ -123,6 +125,8 @@ export const SingleDocActivity = memo(function SingleDocActivity({
                 forceShowCorrectness={forceShowCorrectness}
                 forceShowSolution={forceShowSolution}
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
+                doenetViewerUrl={doenetViewerUrl}
+                doenetMediaUrl={doenetMediaUrl}
                 standaloneUrl={standaloneUrl}
                 cssUrl={cssUrl}
                 fetchExternalDoenetML={fetchExternalDoenetML}

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { DoenetViewer } from "@doenet/doenetml-iframe";
 import { SingleDocState } from "./singleDocState";
 import type { ActivityCommonProps } from "./Activity";
@@ -25,7 +25,9 @@ export const SingleDocActivity = memo(function SingleDocActivity({
     forceShowCorrectness = false,
     forceShowSolution = false,
     forceUnsuppressCheckwork = false,
-    doenetViewerUrl,
+    standaloneUrl,
+    cssUrl,
+    doenetmlVersion,
     fetchExternalDoenetML,
     darkMode = "light",
     showAnswerResponseMenu = false,
@@ -33,14 +35,14 @@ export const SingleDocActivity = memo(function SingleDocActivity({
     state,
     doenetState,
     stateVersion,
+    mountPolicy,
+    useSharedCoreWorker = false,
     reportScoreAndStateCallback,
-    checkRender,
     checkHidden,
+    checkKeepLive,
     allowItemAttemptButtons = false,
     generateNewItemAttempt,
     hasRenderedCallback,
-    reportVisibility = false,
-    reportVisibilityCallback,
     itemAttemptNumber,
     itemWord,
 }: SingleDocActivityProps) {
@@ -59,25 +61,6 @@ export const SingleDocActivity = memo(function SingleDocActivity({
     const [requestedVariantIndex, setRequestedVariantIndex] = useState(
         state.currentVariant,
     );
-
-    const ref = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (reportVisibility && ref.current) {
-            const observer = new IntersectionObserver(
-                ([entry]) => {
-                    reportVisibilityCallback(state.id, entry.isIntersecting);
-                },
-                { rootMargin: "1000px 1000px 1000px 1000px" },
-            );
-
-            observer.observe(ref.current);
-
-            return () => {
-                observer.disconnect();
-            };
-        }
-    }, [reportVisibility, ref, reportVisibilityCallback, state.id]);
 
     // The initial Doenet state is deliberately *frozen*: it seeds the viewer
     // and must not follow every subsequent report (the viewer owns the live
@@ -115,7 +98,6 @@ export const SingleDocActivity = memo(function SingleDocActivity({
         !source.isDescription &&
         maxAttemptsAllowed !== 1;
 
-    const render = checkRender(state);
     const hidden = checkHidden(state);
 
     const newAttemptsLeft = Math.max(maxAttemptsAllowed - itemAttemptNumber, 0);
@@ -123,70 +105,71 @@ export const SingleDocActivity = memo(function SingleDocActivity({
         maxAttemptsAllowed > 0 && newAttemptsLeft <= 0;
 
     return (
-        <div ref={ref}>
-            <div hidden={!render || hidden} style={{ minHeight: "100px" }}>
-                <DoenetViewer
-                    // `initialState` is seed-only for the viewer, so applying
-                    // a re-read one (new item attempt, or externally loaded
-                    // state — which may not change the attempt number)
-                    // requires a remount. Built from the *frozen* values so
-                    // the key and the seed always change in the same commit.
-                    key={`${attemptNumber.toString()}-${stateVersionUsed.toString()}`}
-                    doenetML={source.doenetML}
-                    doenetmlVersion={source.version}
-                    render={render}
-                    requestedVariantIndex={requestedVariantIndex}
-                    flags={flags}
-                    activityId={baseId}
-                    docId={state.id}
-                    forceDisable={forceDisable}
-                    forceShowCorrectness={forceShowCorrectness}
-                    forceShowSolution={forceShowSolution}
-                    forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                    doenetViewerUrl={doenetViewerUrl}
-                    fetchExternalDoenetML={fetchExternalDoenetML}
-                    darkMode={darkMode}
-                    showAnswerResponseMenu={showAnswerResponseMenu}
-                    answerResponseCounts={answerResponseCounts}
-                    addVirtualKeyboard={false}
-                    initialState={initialDoenetState}
-                    initializeCounters={initialCounters}
-                    reportScoreAndStateCallback={reportScoreAndStateCallback}
-                    initializedCallback={() => {
-                        setRendered(true);
-                        hasRenderedCallback(state.id);
+        <div hidden={hidden} style={{ minHeight: "100px" }}>
+            <DoenetViewer
+                // `initialState` is seed-only for the viewer, so applying
+                // a re-read one (new item attempt, or externally loaded
+                // state — which may not change the attempt number)
+                // requires a remount. Built from the *frozen* values so
+                // the key and the seed always change in the same commit.
+                key={`${attemptNumber.toString()}-${stateVersionUsed.toString()}`}
+                doenetML={source.doenetML}
+                doenetmlVersion={doenetmlVersion ?? source.version}
+                requestedVariantIndex={requestedVariantIndex}
+                flags={flags}
+                activityId={baseId}
+                docId={state.id}
+                forceDisable={forceDisable}
+                forceShowCorrectness={forceShowCorrectness}
+                forceShowSolution={forceShowSolution}
+                forceUnsuppressCheckwork={forceUnsuppressCheckwork}
+                standaloneUrl={standaloneUrl}
+                cssUrl={cssUrl}
+                fetchExternalDoenetML={fetchExternalDoenetML}
+                darkMode={darkMode}
+                showAnswerResponseMenu={showAnswerResponseMenu}
+                answerResponseCounts={answerResponseCounts}
+                addVirtualKeyboard={false}
+                initialState={initialDoenetState}
+                initializeCounters={initialCounters}
+                mountPolicy={mountPolicy}
+                keepLive={checkKeepLive(state)}
+                useSharedCoreWorker={useSharedCoreWorker}
+                reportScoreAndStateCallback={reportScoreAndStateCallback}
+                initializedCallback={() => {
+                    setRendered(true);
+                    hasRenderedCallback(state.id);
+                }}
+            />
+            {showAttemptButton ? (
+                <button
+                    hidden={!rendered}
+                    onClick={() => {
+                        generateNewItemAttempt(
+                            state.id,
+                            state.initialQuestionCounter,
+                        );
                     }}
-                />
-                {showAttemptButton ? (
-                    <button
-                        hidden={!rendered}
-                        onClick={() => {
-                            generateNewItemAttempt(
-                                state.id,
-                                state.initialQuestionCounter,
-                            );
-                        }}
-                        disabled={attemptButtonDisabled}
-                        style={{
-                            marginLeft: "20px",
-                            backgroundColor: "var(--buttonSurfaceAlt)",
-                            color: "var(--canvasText)",
-                            opacity: attemptButtonDisabled ? 0.4 : "inherit",
-                            borderRadius: "10px",
-                            padding: "5px 20px",
-                            cursor: attemptButtonDisabled
-                                ? "not-allowed"
-                                : "pointer",
-                        }}
-                        data-test="New Item Attempt"
-                    >
-                        New {itemWord} attempt{" "}
-                        {maxAttemptsAllowed > 0
-                            ? `(${newAttemptsLeft.toString()} left)`
-                            : null}
-                    </button>
-                ) : null}
-            </div>
+                    disabled={attemptButtonDisabled}
+                    style={{
+                        marginLeft: "20px",
+                        backgroundColor: "var(--buttonSurfaceAlt)",
+                        color: "var(--canvasText)",
+                        opacity: attemptButtonDisabled ? 0.4 : "inherit",
+                        borderRadius: "10px",
+                        padding: "5px 20px",
+                        cursor: attemptButtonDisabled
+                            ? "not-allowed"
+                            : "pointer",
+                    }}
+                    data-test="New Item Attempt"
+                >
+                    New {itemWord} attempt{" "}
+                    {maxAttemptsAllowed > 0
+                        ? `(${newAttemptsLeft.toString()} left)`
+                        : null}
+                </button>
+            ) : null}
         </div>
     );
 });

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -23,6 +23,7 @@ import {
     getNumItems,
     createSourceHash,
 } from "../Activity/activityState";
+import type { MountPolicy } from "@doenet/doenetml-iframe";
 import { Activity } from "../Activity/Activity";
 import { activityDoenetStateReducer } from "../Activity/activityStateReducer";
 import { useContentStable } from "../utils/hooks";
@@ -44,13 +45,17 @@ export function Viewer({
     forceUnsuppressCheckwork = false,
     addVirtualKeyboard: _addVirtualKeyboard = true,
     externalVirtualKeyboardProvided: _externalVirtualKeyboardProvided = false,
-    doenetViewerUrl,
+    standaloneUrl,
+    cssUrl,
+    doenetmlVersion,
     fetchExternalDoenetML,
     darkMode = "light",
     showAnswerResponseMenu = false,
     answerResponseCountsByItem = [],
     showTitle = true,
     itemWord = "item",
+    mountPolicy,
+    useSharedCoreWorker = false,
 }: {
     source: ActivitySource;
     flags: DoenetMLFlags;
@@ -68,13 +73,17 @@ export function Viewer({
     forceUnsuppressCheckwork?: boolean;
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
-    doenetViewerUrl?: string;
+    standaloneUrl?: string;
+    cssUrl?: string;
+    doenetmlVersion?: string;
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
     answerResponseCountsByItem?: Record<string, number>[];
     showTitle?: boolean;
     itemWord?: string;
+    mountPolicy: MountPolicy;
+    useSharedCoreWorker?: boolean;
 }) {
     const initialPass = useRef(true);
 
@@ -131,7 +140,7 @@ export function Viewer({
     // Content-stable: every reducer action (each score report included)
     // rebuilds `activityState`, but the sequence of item ids rarely changes.
     // Keeping the previous identity when the ids match lets everything
-    // derived from it (`itemIdsToRender`, `checkRender`, the memoized item
+    // derived from it (`itemIndexById`, the callbacks, the memoized item
     // subtrees) stay stable across reports.
     const computedItemSequence = useMemo(
         () => getItemSequence(activityState),
@@ -152,7 +161,6 @@ export function Viewer({
     const currentItemId = itemSequence[currentItemIdx];
 
     const [itemsRendered, setItemsRendered] = useState<string[]>([]);
-    const [itemsVisible, setItemsVisible] = useState<string[]>([]);
 
     const [newAttemptNum, setNewAttemptNum] = useState(0);
     const dialogRef = useRef<HTMLDialogElement>(null);
@@ -160,64 +168,23 @@ export function Viewer({
 
     const attemptNumber = activityState.attemptNumber;
 
-    // The items allowed to mount their viewer, *derived* from which items
-    // have finished rendering: everything already rendered plus (at most)
-    // one in-flight item — in paginated mode the current item, then a
-    // prefetch of the next and previous; in scroll mode the first visible
-    // unrendered item. Deriving (rather than accumulating in state) keeps
-    // the schedule consistent through attempt resets and item regeneration,
-    // which simply remove ids from `itemsRendered`.
-    const itemIdsToRender = useMemo(() => {
-        const toRender = new Set(itemsRendered);
-        if (paginate) {
-            const currentItemId = itemSequence[currentItemIdx];
-            toRender.add(currentItemId);
-            if (itemsRendered.includes(currentItemId)) {
-                const nextItemId = itemSequence[currentItemIdx + 1];
-                if (currentItemIdx < numItems - 1) {
-                    // prefetch the next item once the current one rendered
-                    toRender.add(nextItemId);
-                }
-                if (
-                    currentItemIdx > 0 &&
-                    (currentItemIdx >= numItems - 1 ||
-                        itemsRendered.includes(nextItemId))
-                ) {
-                    // then the previous item
-                    toRender.add(itemSequence[currentItemIdx - 1]);
-                }
-            }
-        } else {
-            const visibleSet = new Set(itemsVisible);
-            for (const id of itemSequence) {
-                // `toRender` still equals the rendered set here (nothing was
-                // added in this branch), so it doubles as the fast
-                // membership test.
-                if (!toRender.has(id) && visibleSet.has(id)) {
-                    toRender.add(id);
-                    break;
-                }
-            }
-        }
-        return toRender;
-    }, [
-        paginate,
-        itemsRendered,
-        itemsVisible,
-        itemSequence,
-        currentItemIdx,
-        numItems,
-    ]);
-
-    const checkRender = useCallback(
+    // Every item's viewer is always mounted; the windowed mounting policy
+    // (`mountPolicy`) decides which of them are actually booted, parking the
+    // rest as placeholders. In paginated mode the current page and its
+    // neighbors are marked `keepLive` so they boot eagerly (hidden pages
+    // never intersect the viewport) and page flips within the window are
+    // instant; in scroll mode visibility alone governs.
+    const checkKeepLive = useCallback(
         (state: ActivityState) => {
-            if (state.type === "singleDoc") {
-                return itemIdsToRender.has(state.id);
-            } else {
-                return true;
+            if (!paginate || state.type !== "singleDoc") {
+                return false;
             }
+            const itemIdx = itemIndexById.get(state.id);
+            return (
+                itemIdx !== undefined && Math.abs(itemIdx - currentItemIdx) <= 1
+            );
         },
-        [itemIdsToRender],
+        [paginate, itemIndexById, currentItemIdx],
     );
 
     const checkHidden = useCallback(
@@ -401,25 +368,6 @@ export function Viewer({
     const hasRenderedCallback = useCallback((id: string) => {
         setItemsRendered((was) => (was.includes(id) ? was : [...was, id]));
     }, []);
-
-    const reportVisibilityCallback = useCallback(
-        (id: string, isVisible: boolean) => {
-            setItemsVisible((was) => {
-                if (isVisible) {
-                    return was.includes(id) ? was : [...was, id];
-                } else {
-                    const idx = was.indexOf(id);
-                    if (idx === -1) {
-                        return was;
-                    }
-                    const obj = [...was];
-                    obj.splice(idx, 1);
-                    return obj;
-                }
-            });
-        },
-        [],
-    );
 
     function generateActivityAttempt() {
         setItemsRendered([]);
@@ -627,7 +575,9 @@ export function Viewer({
                 forceShowCorrectness={forceShowCorrectness}
                 forceShowSolution={forceShowSolution}
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
-                doenetViewerUrl={doenetViewerUrl}
+                standaloneUrl={standaloneUrl}
+                cssUrl={cssUrl}
+                doenetmlVersion={doenetmlVersion}
                 fetchExternalDoenetML={fetchExternalDoenetML}
                 darkMode={darkMode}
                 showAnswerResponseMenu={showAnswerResponseMenu}
@@ -635,14 +585,14 @@ export function Viewer({
                 state={activityState}
                 doenetStates={activityDoenetState.doenetStates}
                 stateVersion={stateVersion}
+                mountPolicy={mountPolicy}
+                useSharedCoreWorker={useSharedCoreWorker}
                 reportScoreAndStateCallback={reportScoreAndStateCallback}
-                checkRender={checkRender}
                 checkHidden={checkHidden}
+                checkKeepLive={checkKeepLive}
                 allowItemAttemptButtons={itemLevelAttempts}
                 generateNewItemAttempt={generateNewItemAttemptPrompt}
                 hasRenderedCallback={hasRenderedCallback}
-                reportVisibility={!paginate}
-                reportVisibilityCallback={reportVisibilityCallback}
                 itemAttemptNumbers={activityDoenetState.itemAttemptNumbers}
                 itemIndexById={itemIndexById}
                 itemWord={itemWord}

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -45,6 +45,8 @@ export function Viewer({
     forceUnsuppressCheckwork = false,
     addVirtualKeyboard: _addVirtualKeyboard = true,
     externalVirtualKeyboardProvided: _externalVirtualKeyboardProvided = false,
+    doenetViewerUrl,
+    doenetMediaUrl,
     standaloneUrl,
     cssUrl,
     doenetmlVersion,
@@ -73,6 +75,8 @@ export function Viewer({
     forceUnsuppressCheckwork?: boolean;
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
+    doenetViewerUrl?: string;
+    doenetMediaUrl?: string;
     standaloneUrl?: string;
     cssUrl?: string;
     doenetmlVersion?: string;
@@ -575,6 +579,8 @@ export function Viewer({
                 forceShowCorrectness={forceShowCorrectness}
                 forceShowSolution={forceShowSolution}
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
+                doenetViewerUrl={doenetViewerUrl}
+                doenetMediaUrl={doenetMediaUrl}
                 standaloneUrl={standaloneUrl}
                 cssUrl={cssUrl}
                 doenetmlVersion={doenetmlVersion}

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -9,6 +9,7 @@ import {
     useState,
 } from "react";
 import seedrandom from "seedrandom";
+import type { MountPolicy } from "@doenet/doenetml-iframe";
 import { Viewer } from "./Viewer/Viewer";
 import { DoenetMLFlags } from "./types";
 import {
@@ -17,6 +18,7 @@ import {
 } from "./Activity/activityState";
 import { useResolvedTheme } from "./utils/theme";
 import type { ThemeSetting } from "./utils/theme";
+import { useContentStable } from "./utils/hooks";
 
 /**
  * A condition in the provided activity worth surfacing to the user — passed
@@ -79,7 +81,11 @@ export function ActivityViewer({
     forceUnsuppressCheckwork = false,
     addVirtualKeyboard = true,
     externalVirtualKeyboardProvided = false,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- the deprecated alias must still be honored
     doenetViewerUrl,
+    standaloneUrl,
+    cssUrl,
+    doenetmlVersion,
     fetchExternalDoenetML,
     darkMode = "system",
     showAnswerResponseMenu = false,
@@ -88,6 +94,8 @@ export function ActivityViewer({
     showTitle = true,
     itemWord = "item",
     reportWarningsCallback,
+    mountPolicy,
+    useSharedCoreWorker = false,
 }: {
     source: ActivitySource;
     flags?: DoenetMLFlagsSubset;
@@ -105,7 +113,20 @@ export function ActivityViewer({
     forceUnsuppressCheckwork?: boolean;
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
+    /** @deprecated Use `standaloneUrl`. */
     doenetViewerUrl?: string;
+    /**
+     * URL of a standalone DoenetML bundle to use for every document,
+     * instead of the CDN bundle for each document's `version`.
+     */
+    standaloneUrl?: string;
+    /** URL of the CSS file that styles the standalone bundle. */
+    cssUrl?: string;
+    /**
+     * Render every document with this DoenetML version, overriding each
+     * document's own `version`.
+     */
+    doenetmlVersion?: string;
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     darkMode?: ThemeSetting;
     showAnswerResponseMenu?: boolean;
@@ -122,6 +143,21 @@ export function ActivityViewer({
      * developers.
      */
     reportWarningsCallback?: (warnings: ActivityViewerWarning[]) => void;
+    /**
+     * Overrides for the windowed mounting policy every document's viewer
+     * registers with (see `MountPolicy` in `@doenet/doenetml-iframe`):
+     * at most `maxLiveViewers` viewers stay booted, the rest are parked
+     * losslessly as placeholders and restored near the viewport. Parking
+     * requires `flags.allowSaveState` or `flags.allowLocalState`; without
+     * them viewers still mount lazily but stay live once booted.
+     */
+    mountPolicy?: Partial<Omit<MountPolicy, "mode">>;
+    /**
+     * Serve all documents' cores from a shared worker pool instead of one
+     * dedicated ~100 MB worker per document (see `useSharedCoreWorker` in
+     * `@doenet/doenetml-iframe`). Default off.
+     */
+    useSharedCoreWorker?: boolean;
 }) {
     const [initialVariantIndex, setInitialVariantIndex] = useState<
         number | null
@@ -189,6 +225,15 @@ export function ActivityViewer({
         [specifiedFlags],
     );
 
+    // Windowed mounting is the default: memory tracks what the student can
+    // see (the pagination window / viewport) instead of assignment length.
+    // Content-stable so a consumer passing an inline `mountPolicy` object
+    // doesn't hand the memoized item subtrees a fresh identity every render.
+    const resolvedMountPolicy = useContentStable<MountPolicy>(
+        useMemo(() => ({ mode: "windowed", ...mountPolicy }), [mountPolicy]),
+        JSON.stringify(mountPolicy ?? {}),
+    );
+
     // Normalize variant index to an integer.
     // Generate a random variant index if the requested variant index is undefined.
     // To preserve the generated variant index on rerender, regenerate only
@@ -234,13 +279,17 @@ export function ActivityViewer({
                     externalVirtualKeyboardProvided={
                         externalVirtualKeyboardProvided
                     }
-                    doenetViewerUrl={doenetViewerUrl}
+                    standaloneUrl={standaloneUrl ?? doenetViewerUrl}
+                    cssUrl={cssUrl}
+                    doenetmlVersion={doenetmlVersion}
                     fetchExternalDoenetML={fetchExternalDoenetML}
                     darkMode={resolvedTheme}
                     showAnswerResponseMenu={showAnswerResponseMenu}
                     answerResponseCountsByItem={answerResponseCountsByItem}
                     showTitle={showTitle}
                     itemWord={itemWord}
+                    mountPolicy={resolvedMountPolicy}
+                    useSharedCoreWorker={useSharedCoreWorker}
                 />
             </div>
         </ErrorBoundary>

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -81,8 +81,8 @@ export function ActivityViewer({
     forceUnsuppressCheckwork = false,
     addVirtualKeyboard = true,
     externalVirtualKeyboardProvided = false,
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- the deprecated alias must still be honored
     doenetViewerUrl,
+    doenetMediaUrl,
     standaloneUrl,
     cssUrl,
     doenetmlVersion,
@@ -113,8 +113,18 @@ export function ActivityViewer({
     forceUnsuppressCheckwork?: boolean;
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
-    /** @deprecated Use `standaloneUrl`. */
+    /**
+     * URL the `<ref>` renderer uses to build links to other Doenet
+     * activities. Forwarded to each document's viewer, which defaults it to
+     * `https://doenet.org/activityViewer`.
+     */
     doenetViewerUrl?: string;
+    /**
+     * URL used to resolve `<image source="doenet:…">` media references.
+     * Forwarded to each document's viewer, which defaults it to
+     * `https://doenet.org/api/media`.
+     */
+    doenetMediaUrl?: string;
     /**
      * URL of a standalone DoenetML bundle to use for every document,
      * instead of the CDN bundle for each document's `version`.
@@ -279,7 +289,9 @@ export function ActivityViewer({
                     externalVirtualKeyboardProvided={
                         externalVirtualKeyboardProvided
                     }
-                    standaloneUrl={standaloneUrl ?? doenetViewerUrl}
+                    doenetViewerUrl={doenetViewerUrl}
+                    doenetMediaUrl={doenetMediaUrl}
+                    standaloneUrl={standaloneUrl}
                     cssUrl={cssUrl}
                     doenetmlVersion={doenetmlVersion}
                     fetchExternalDoenetML={fetchExternalDoenetML}

--- a/test/cypress/component/ActivityViewer.viewerUrls.cy.tsx
+++ b/test/cypress/component/ActivityViewer.viewerUrls.cy.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { ActivityViewer } from "../../../src/activity-viewer";
+import type { ActivitySource } from "../../../src/Activity/activityState";
+import {
+    STANDALONE_URL,
+    STANDALONE_CSS_URL,
+    IFRAME_READY_TIMEOUT,
+} from "./helpers";
+
+// `doenetViewerUrl` (the `<ref>` renderer's activity-link base) and
+// `doenetMediaUrl` (the `<image source="doenet:…">` base, DoenetML#1457) are
+// props of the inner DoenetViewer. ActivityViewer must thread them through
+// Viewer → Activity → SingleDocActivity to each embedded `<DoenetViewer>`.
+// The iframe wrapper bakes a booted viewer's props into the iframe `srcdoc`,
+// so a forwarded URL shows up there — a stable check that does not depend on
+// the bundle rendering a ref/image.
+
+const VIEWER_URL = "https://viewer.example.test/activityViewer";
+const MEDIA_URL = "https://media.example.test/api/media";
+
+const SOURCE: ActivitySource = {
+    type: "singleDoc",
+    id: "doc",
+    doenetML: "<p>hello</p>",
+    version: "0.7.4",
+    isDescription: false,
+    numVariants: 1,
+} as ActivitySource;
+
+describe("ActivityViewer — forwards doenetViewerUrl and doenetMediaUrl to the viewer", () => {
+    it("bakes both URLs into the embedded DoenetViewer's iframe", () => {
+        cy.mount(
+            <ActivityViewer
+                source={SOURCE}
+                activityId="urls"
+                addVirtualKeyboard={false}
+                standaloneUrl={STANDALONE_URL}
+                cssUrl={STANDALONE_CSS_URL}
+                doenetViewerUrl={VIEWER_URL}
+                doenetMediaUrl={MEDIA_URL}
+            />,
+        );
+
+        cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+            .should("have.attr", "srcdoc")
+            .and("include", VIEWER_URL)
+            .and("include", MEDIA_URL);
+    });
+});

--- a/test/cypress/component/ActivityViewer.windowed.cy.tsx
+++ b/test/cypress/component/ActivityViewer.windowed.cy.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { ActivityViewer } from "../../../src/activity-viewer";
+import type { ActivitySource } from "../../../src/Activity/activityState";
+import type { SingleDocSource } from "../../../src/Activity/singleDocState";
+import {
+    WINDOWED_STANDALONE_URL,
+    WINDOWED_STANDALONE_CSS_URL,
+    IFRAME_READY_TIMEOUT,
+    PARK_TIMEOUT,
+} from "./helpers";
+
+// Windowed mounting (#35, #36, #37): every item's DoenetViewer is mounted,
+// but the wrapper's mountPolicy decides which are booted — memory tracks the
+// pagination window / viewport, not assignment length. Parking is lossless:
+// state is flushed before the iframe is detached and restored on return.
+
+function mkDoc(id: string, label: string): SingleDocSource {
+    return {
+        id,
+        type: "singleDoc",
+        isDescription: false,
+        doenetML: `<p>${label}: <textInput name="ti" /></p><p>typed: $ti.value</p>`,
+        version: "0.7.4",
+        numVariants: 1,
+    };
+}
+
+function mkSequence(numDocs: number): ActivitySource {
+    return {
+        type: "sequence",
+        id: "seq",
+        title: "windowed",
+        shuffle: false,
+        items: Array.from({ length: numDocs }, (_, i) =>
+            mkDoc(`doc${(i + 1).toString()}`, `Doc ${(i + 1).toString()}`),
+        ),
+    } as ActivitySource;
+}
+
+/**
+ * The iframe of the item with the given id: the DoenetViewer bakes its
+ * props (including `docId`) into the iframe's srcdoc. A windowed viewer
+ * only has an iframe while booted — parked viewers are placeholders.
+ */
+function itemIframe(id: string, options?: { timeout?: number }) {
+    return cy.get(`iframe[srcdoc*='"docId":"${id}"']`, options);
+}
+
+/** Assert rendered (script-stripped) iframe content for an item. */
+function assertItemContent(id: string, text: string) {
+    itemIframe(id)
+        .its("0.contentDocument.body", { timeout: IFRAME_READY_TIMEOUT })
+        .should((body: HTMLElement) => {
+            const clone = body.cloneNode(true) as HTMLElement;
+            clone.querySelectorAll("script").forEach((s) => {
+                s.remove();
+            });
+            expect(clone.textContent).to.contain(text);
+        });
+}
+
+describe("ActivityViewer — windowed mounting", () => {
+    it("paginated: keeps the window live, parks beyond it, and restores typed work", () => {
+        cy.viewport(900, 700);
+        cy.mount(
+            <ActivityViewer
+                source={mkSequence(5)}
+                activityId="windowed-paginated"
+                flags={{ allowSaveState: true }}
+                paginate={true}
+                standaloneUrl={WINDOWED_STANDALONE_URL}
+                cssUrl={WINDOWED_STANDALONE_CSS_URL}
+                addVirtualKeyboard={false}
+                mountPolicy={{ parkDelayMs: 300, flushTimeoutMs: 15_000 }}
+            />,
+        );
+
+        // Page 1 (current, keepLive) boots and renders; its neighbor
+        // prefetches in the background. Pages beyond the window never boot.
+        assertItemContent("doc1", "typed:");
+        itemIframe("doc2", { timeout: IFRAME_READY_TIMEOUT }).should("exist");
+        cy.get("iframe").should("have.length.at.most", 3);
+        itemIframe("doc4").should("not.exist");
+        itemIframe("doc5").should("not.exist");
+
+        // Type into page 1 and commit with Enter.
+        itemIframe("doc1")
+            .its("0.contentDocument.body")
+            .find("input:not([type=checkbox])")
+            .then(($el) => cy.wrap($el))
+            .type("windowed work{enter}");
+        assertItemContent("doc1", "typed: windowed work");
+
+        // Page forward to 4: the window moves; doc1 leaves it and parks
+        // (iframe detached), and the live-iframe count stays bounded.
+        cy.contains("button", "Next").click();
+        cy.contains("button", "Next").click();
+        cy.contains("button", "Next").click();
+        assertItemContent("doc4", "typed:");
+        itemIframe("doc1", { timeout: PARK_TIMEOUT }).should("not.exist");
+        cy.get("iframe", { timeout: PARK_TIMEOUT }).should(
+            "have.length.at.most",
+            3,
+        );
+
+        // Page back to 1: it restores — typed work intact, no interaction.
+        cy.contains("button", "Previous").click();
+        cy.contains("button", "Previous").click();
+        cy.contains("button", "Previous").click();
+        assertItemContent("doc1", "typed: windowed work");
+        itemIframe("doc1")
+            .its("0.contentDocument.body", { timeout: IFRAME_READY_TIMEOUT })
+            .find("input:not([type=checkbox])")
+            .should("have.value", "windowed work");
+    });
+
+    it("scroll mode: off-screen items never boot; scrolling boots them and parks the ones left behind", () => {
+        cy.viewport(900, 600);
+        cy.mount(
+            <ActivityViewer
+                source={mkSequence(5)}
+                activityId="windowed-scroll"
+                flags={{ allowSaveState: true }}
+                paginate={false}
+                standaloneUrl={WINDOWED_STANDALONE_URL}
+                cssUrl={WINDOWED_STANDALONE_CSS_URL}
+                addVirtualKeyboard={false}
+                mountPolicy={{
+                    maxLiveViewers: 2,
+                    visibleMargin: "100px",
+                    parkDelayMs: 300,
+                    flushTimeoutMs: 15_000,
+                }}
+            />,
+        );
+
+        // The first item (in the viewport) boots; the last is far below the
+        // 100px margin (parked placeholders are ~500px tall) and never does.
+        assertItemContent("doc1", "typed:");
+        itemIframe("doc5").should("not.exist");
+
+        // Scroll to the bottom: the far items boot; the ones left behind
+        // exceed the budget of 2 and park (bounded iframe count).
+        cy.scrollTo("bottom", { duration: 500 });
+        assertItemContent("doc5", "typed:");
+        itemIframe("doc1", { timeout: PARK_TIMEOUT }).should("not.exist");
+        cy.get("iframe", { timeout: PARK_TIMEOUT }).should(
+            "have.length.at.most",
+            2,
+        );
+    });
+});

--- a/test/cypress/component/helpers.ts
+++ b/test/cypress/component/helpers.ts
@@ -14,3 +14,14 @@ export const STANDALONE_CSS_URL = `${CDN}/style.css`;
 // Budget enough time for the standalone bundle to evaluate inside the iframe
 // on a cold CDN fetch.
 export const IFRAME_READY_TIMEOUT = 20_000;
+
+// The windowed-mounting specs park viewers, which requires a standalone
+// bundle that acknowledges `SPLICE.flushState` — true of the bundle
+// published alongside the installed doenetml-iframe version (the wrapper
+// treats a host-specified standaloneUrl as modern).
+export const WINDOWED_STANDALONE_URL = STANDALONE_URL;
+export const WINDOWED_STANDALONE_CSS_URL = STANDALONE_CSS_URL;
+
+// Parking additionally waits for the off-screen viewer's realm to boot far
+// enough to acknowledge the flush.
+export const PARK_TIMEOUT = 40_000;


### PR DESCRIPTION
Fixes #35, fixes #36, and fixes #37. Requires `@doenet/doenetml-iframe ≥ 0.7.20-dev.332` (windowed mounting with `keepLive` and report-callback host support, Doenet/DoenetML#1479).

Every item's viewer component stays mounted, but which items are **booted** is now governed by the iframe wrapper's windowed mounting policy:

- An item only creates its iframe (a multi-MB standalone-bundle parse plus a core worker) when it comes near the viewport or into the pagination window — an item the student never reaches never boots at all (#35), and simultaneous boots are capped page-wide.
- At most `maxLiveViewers` (default 3) stay live; the rest are **parked** losslessly — their state is flushed before the iframe is detached, and they are restored (typed work intact, no interaction) when the student returns. A 20-question assignment paged all the way through holds ~3 live viewers instead of 20 (#36); scroll-mode memory tracks the viewport (#37).
- In paginated mode the current page and its neighbors are marked `keepLive`, so page flips within the window stay instant while hidden pages beyond it never boot.

The viewer's own render-scheduling machinery (`itemsToRender`/`itemsVisible`/`checkRender`/per-item `IntersectionObserver`) is deleted in favor of the wrapper's policy. Parking requires `flags.allowSaveState` or `allowLocalState`; without a persistence path viewers still mount lazily but stay live once booted, so no work can be lost.

New `ActivityViewer` props:

- `mountPolicy` — overrides for `maxLiveViewers` / `visibleMargin` / `parkDelayMs` / `flushTimeoutMs` / `maxConcurrentBoots`;
- `useSharedCoreWorker` — serve all documents' cores from a shared worker pool instead of one dedicated ~100 MB worker per document (default off);
- working `standaloneUrl` / `cssUrl` / `doenetmlVersion` passthroughs — the standalone-bundle URL, its CSS, and a version override for every document's viewer;
- `doenetViewerUrl` and `doenetMediaUrl` are threaded through `Viewer` → `Activity` → `SingleDocActivity` to each embedded `DoenetViewer`. Both are inner-viewer props (forwarded across the iframe boundary), not bundle URLs: `doenetViewerUrl` is the `<ref>` renderer's activity-link base (it was not being forwarded correctly), and `doenetMediaUrl` is the `<image source="doenet:…">` media base (Doenet/DoenetML#1457), newly exposed so `doenet:` images resolve.

## Tests

New cypress spec (against the real published dev-channel bundle) covering both modes end to end:

- **Paginated** (5 docs): current+neighbor boot, pages beyond the window never do, iframe count stays ≤ 3; typing on page 1, paging to 4 (page 1 parks — iframe detached), and returning restores the typed work with no interaction.
- **Scroll** (5 docs, budget 2): off-screen items never boot; scrolling boots the far items and parks the ones left behind (iframe count ≤ 2).

A separate spec asserts that `doenetViewerUrl` and `doenetMediaUrl` reach the embedded viewer — both are baked into the booted `DoenetViewer`'s iframe `srcdoc`, confirming they thread all the way through.

The park/restore round trip also exercises DoenetML#1479's report-callback capture path in a real host. Full suite green (47 vitest + 14 cypress), lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


