### PR TITLE
Rename doenetMediaUrl prop to doenetImagesUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "seedrandom": "^3.0.5"
             },
             "devDependencies": {
-                "@doenet/doenetml-iframe": "0.7.20-dev.332",
+                "@doenet/doenetml-iframe": "0.7.20-dev.334",
                 "@eslint/js": "^9.39.1",
                 "@types/object-hash": "^3.0.6",
                 "@types/react": "^19.2.7",
@@ -39,7 +39,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "^0.7.20-dev.332",
+                "@doenet/doenetml-iframe": "^0.7.20-dev.334",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }
@@ -335,9 +335,9 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.20-dev.332",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.332.tgz",
-            "integrity": "sha512-V6/fa/ZOFfd3lFlaXabArMpMBlSv9xOfnHOEBfy3mRhizjwucriu2PxdV/GnynA/G6Y2Ayve3y7nK7PTGoaq/Q==",
+            "version": "0.7.20-dev.334",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.334.tgz",
+            "integrity": "sha512-25n4rFh6GAJgkUofo0WOTYoSJVfSCxDGrREYVgvGqGk5QttTGdQ0sLK4ubGzc6WLE+YRLPvxVtcuc/OUT6faUA==",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "prettier:check": "prettier --check ."
     },
     "peerDependencies": {
-        "@doenet/doenetml-iframe": "^0.7.20-dev.332",
+        "@doenet/doenetml-iframe": "^0.7.20-dev.334",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
     },
@@ -49,7 +49,7 @@
         "seedrandom": "^3.0.5"
     },
     "devDependencies": {
-        "@doenet/doenetml-iframe": "0.7.20-dev.332",
+        "@doenet/doenetml-iframe": "0.7.20-dev.334",
         "@eslint/js": "^9.39.1",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.7",

--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -17,7 +17,7 @@ export type ActivityCommonProps = {
     /** URL the `<ref>` renderer uses to link to other Doenet activities. */
     doenetViewerUrl?: string;
     /** URL used to resolve `<image source="doenet:…">` media references. */
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     standaloneUrl?: string;
     cssUrl?: string;
     doenetmlVersion?: string;

--- a/src/Activity/SingleDocActivity.tsx
+++ b/src/Activity/SingleDocActivity.tsx
@@ -26,7 +26,7 @@ export const SingleDocActivity = memo(function SingleDocActivity({
     forceShowSolution = false,
     forceUnsuppressCheckwork = false,
     doenetViewerUrl,
-    doenetMediaUrl,
+    doenetImagesUrl,
     standaloneUrl,
     cssUrl,
     doenetmlVersion,
@@ -126,7 +126,7 @@ export const SingleDocActivity = memo(function SingleDocActivity({
                 forceShowSolution={forceShowSolution}
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                 doenetViewerUrl={doenetViewerUrl}
-                doenetMediaUrl={doenetMediaUrl}
+                doenetImagesUrl={doenetImagesUrl}
                 standaloneUrl={standaloneUrl}
                 cssUrl={cssUrl}
                 fetchExternalDoenetML={fetchExternalDoenetML}

--- a/src/Viewer/Viewer.tsx
+++ b/src/Viewer/Viewer.tsx
@@ -46,7 +46,7 @@ export function Viewer({
     addVirtualKeyboard: _addVirtualKeyboard = true,
     externalVirtualKeyboardProvided: _externalVirtualKeyboardProvided = false,
     doenetViewerUrl,
-    doenetMediaUrl,
+    doenetImagesUrl,
     standaloneUrl,
     cssUrl,
     doenetmlVersion,
@@ -76,7 +76,7 @@ export function Viewer({
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
     doenetViewerUrl?: string;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     standaloneUrl?: string;
     cssUrl?: string;
     doenetmlVersion?: string;
@@ -580,7 +580,7 @@ export function Viewer({
                 forceShowSolution={forceShowSolution}
                 forceUnsuppressCheckwork={forceUnsuppressCheckwork}
                 doenetViewerUrl={doenetViewerUrl}
-                doenetMediaUrl={doenetMediaUrl}
+                doenetImagesUrl={doenetImagesUrl}
                 standaloneUrl={standaloneUrl}
                 cssUrl={cssUrl}
                 doenetmlVersion={doenetmlVersion}

--- a/src/activity-viewer.tsx
+++ b/src/activity-viewer.tsx
@@ -82,7 +82,7 @@ export function ActivityViewer({
     addVirtualKeyboard = true,
     externalVirtualKeyboardProvided = false,
     doenetViewerUrl,
-    doenetMediaUrl,
+    doenetImagesUrl,
     standaloneUrl,
     cssUrl,
     doenetmlVersion,
@@ -124,7 +124,7 @@ export function ActivityViewer({
      * Forwarded to each document's viewer, which defaults it to
      * `https://doenet.org/api/media`.
      */
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     /**
      * URL of a standalone DoenetML bundle to use for every document,
      * instead of the CDN bundle for each document's `version`.
@@ -290,7 +290,7 @@ export function ActivityViewer({
                         externalVirtualKeyboardProvided
                     }
                     doenetViewerUrl={doenetViewerUrl}
-                    doenetMediaUrl={doenetMediaUrl}
+                    doenetImagesUrl={doenetImagesUrl}
                     standaloneUrl={standaloneUrl}
                     cssUrl={cssUrl}
                     doenetmlVersion={doenetmlVersion}

--- a/test/cypress/component/ActivityViewer.viewerUrls.cy.tsx
+++ b/test/cypress/component/ActivityViewer.viewerUrls.cy.tsx
@@ -8,7 +8,7 @@ import {
 } from "./helpers";
 
 // `doenetViewerUrl` (the `<ref>` renderer's activity-link base) and
-// `doenetMediaUrl` (the `<image source="doenet:…">` base, DoenetML#1457) are
+// `doenetImagesUrl` (the `<image source="doenet:…">` base, DoenetML#1457) are
 // props of the inner DoenetViewer. ActivityViewer must thread them through
 // Viewer → Activity → SingleDocActivity to each embedded `<DoenetViewer>`.
 // The iframe wrapper bakes a booted viewer's props into the iframe `srcdoc`,
@@ -16,7 +16,7 @@ import {
 // the bundle rendering a ref/image.
 
 const VIEWER_URL = "https://viewer.example.test/activityViewer";
-const MEDIA_URL = "https://media.example.test/api/media";
+const IMAGES_URL = "https://images.example.test/api/media";
 
 const SOURCE: ActivitySource = {
     type: "singleDoc",
@@ -27,7 +27,7 @@ const SOURCE: ActivitySource = {
     numVariants: 1,
 } as ActivitySource;
 
-describe("ActivityViewer — forwards doenetViewerUrl and doenetMediaUrl to the viewer", () => {
+describe("ActivityViewer — forwards doenetViewerUrl and doenetImagesUrl to the viewer", () => {
     it("bakes both URLs into the embedded DoenetViewer's iframe", () => {
         cy.mount(
             <ActivityViewer
@@ -37,13 +37,13 @@ describe("ActivityViewer — forwards doenetViewerUrl and doenetMediaUrl to the 
                 standaloneUrl={STANDALONE_URL}
                 cssUrl={STANDALONE_CSS_URL}
                 doenetViewerUrl={VIEWER_URL}
-                doenetMediaUrl={MEDIA_URL}
+                doenetImagesUrl={IMAGES_URL}
             />,
         );
 
         cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
             .should("have.attr", "srcdoc")
             .and("include", VIEWER_URL)
-            .and("include", MEDIA_URL);
+            .and("include", IMAGES_URL);
     });
 });


### PR DESCRIPTION
Mirrors [DoenetML#1485](https://github.com/Doenet/DoenetML/pull/1485), which renamed the `doenetMediaUrl` prop to `doenetImagesUrl` (the base URL used to resolve `<image source="doenet:…">` references).

## Changes

- Rename the `doenetMediaUrl` prop to `doenetImagesUrl` throughout, threading the new name through `ActivityViewer` → `Viewer` → `Activity` → `SingleDocActivity` to each embedded `<DoenetViewer>`.
- Bump `@doenet/doenetml-iframe` `0.7.20-dev.332` → `0.7.20-dev.334`, the newest dev version, so the underlying viewer accepts the renamed prop.
- Update the `ActivityViewer.viewerUrls` component test to the new prop name.

No deprecation of the old name, since it was never released.

## Verification

- `tsc`, eslint, and prettier pass on the changed files.
- The `ActivityViewer.viewerUrls` cypress component test passes, confirming `doenetImagesUrl` still forwards end-to-end into the embedded viewer's iframe `srcdoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
