### PR TITLE
Upgrade to DoenetML 0.7.21 and drop the parking standaloneUrl workaround

### DIFF
--- a/dev/testActivity.json
+++ b/dev/testActivity.json
@@ -16,7 +16,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>2+2=<answer>4</answer><selectFromSequence /></problem>",
-                    "version": "0.7.20-dev.332",
+                    "version": "0.7.21",
                     "numVariants": 10
                 },
                 {
@@ -25,7 +25,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>1+1=<answer>2</answer><selectFromSequence length='3' /></problem><problem>4+4=<answer>8</answer><selectFromSequence length='4' /></problem>",
-                    "version": "0.7.20-dev.332",
+                    "version": "0.7.21",
                     "numVariants": 12
                 }
             ]
@@ -41,7 +41,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1A <graph><point name='P'/></graph><answer><award><when>$P.x > 0</when></award></answer></question>",
-                    "version": "0.7.20-dev.332",
+                    "version": "0.7.21",
                     "numVariants": 1
                 },
                 {
@@ -49,7 +49,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1B <p>Enter: <select name='a'>a b c</select>. <answer>$a</answer></p></question>",
-                    "version": "0.7.20-dev.332",
+                    "version": "0.7.21",
                     "numVariants": 3
                 },
                 {
@@ -57,7 +57,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1C <p>Enter: <selectFromSequence name='a' />. <answer>$a</answer></p></question>",
-                    "version": "0.7.20-dev.332",
+                    "version": "0.7.21",
                     "numVariants": 10
                 },
                 {
@@ -65,7 +65,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1D <p>Enter: <selectFromSequence name='a' length=\"5\" />.  <answer>$a</answer></p></question>",
-                    "version": "0.7.20-dev.332",
+                    "version": "0.7.21",
                     "numVariants": 5
                 }
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha-15",
+    "version": "0.1.0-alpha-16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha-15",
+            "version": "0.1.0-alpha-16",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "nanoid": "^5.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "seedrandom": "^3.0.5"
             },
             "devDependencies": {
-                "@doenet/doenetml-iframe": "0.7.20-dev.334",
+                "@doenet/doenetml-iframe": "0.7.21",
                 "@eslint/js": "^9.39.1",
                 "@types/object-hash": "^3.0.6",
                 "@types/react": "^19.2.7",
@@ -39,7 +39,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "^0.7.20-dev.334",
+                "@doenet/doenetml-iframe": "^0.7.21",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }
@@ -335,9 +335,9 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.20-dev.334",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.20-dev.334.tgz",
-            "integrity": "sha512-25n4rFh6GAJgkUofo0WOTYoSJVfSCxDGrREYVgvGqGk5QttTGdQ0sLK4ubGzc6WLE+YRLPvxVtcuc/OUT6faUA==",
+            "version": "0.7.21",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.21.tgz",
+            "integrity": "sha512-Jjnh1BqBd+gqoh+K/OeHIHTUS0Ej4LjxztdMT/mjTcSiZvSs/b48VlVUEURoTE32z0rUZSFAzWQlC7FFEaQ8Wg==",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "prettier:check": "prettier --check ."
     },
     "peerDependencies": {
-        "@doenet/doenetml-iframe": "^0.7.20-dev.334",
+        "@doenet/doenetml-iframe": "^0.7.21",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
     },
@@ -49,7 +49,7 @@
         "seedrandom": "^3.0.5"
     },
     "devDependencies": {
-        "@doenet/doenetml-iframe": "0.7.20-dev.334",
+        "@doenet/doenetml-iframe": "0.7.21",
         "@eslint/js": "^9.39.1",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha-15",
+    "version": "0.1.0-alpha-16",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",

--- a/test/cypress/component/ActivityViewer.windowed.cy.tsx
+++ b/test/cypress/component/ActivityViewer.windowed.cy.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import { ActivityViewer } from "../../../src/activity-viewer";
 import type { ActivitySource } from "../../../src/Activity/activityState";
 import type { SingleDocSource } from "../../../src/Activity/singleDocState";
-import {
-    WINDOWED_STANDALONE_URL,
-    WINDOWED_STANDALONE_CSS_URL,
-    IFRAME_READY_TIMEOUT,
-    PARK_TIMEOUT,
-} from "./helpers";
+import { IFRAME_READY_TIMEOUT, PARK_TIMEOUT } from "./helpers";
 
 // Windowed mounting (#35, #36, #37): every item's DoenetViewer is mounted,
 // but the wrapper's mountPolicy decides which are booted — memory tracks the
@@ -20,7 +15,10 @@ function mkDoc(id: string, label: string): SingleDocSource {
         type: "singleDoc",
         isDescription: false,
         doenetML: `<p>${label}: <textInput name="ti" /></p><p>typed: $ti.value</p>`,
-        version: "0.7.4",
+        // 0.7.21 is the first version the iframe wrapper gates parking on
+        // (PARK_MIN_VERSION), so parking works without a host-specified
+        // standaloneUrl — the bundle/CSS auto-resolve from this version.
+        version: "0.7.21",
         numVariants: 1,
     };
 }
@@ -68,8 +66,6 @@ describe("ActivityViewer — windowed mounting", () => {
                 activityId="windowed-paginated"
                 flags={{ allowSaveState: true }}
                 paginate={true}
-                standaloneUrl={WINDOWED_STANDALONE_URL}
-                cssUrl={WINDOWED_STANDALONE_CSS_URL}
                 addVirtualKeyboard={false}
                 mountPolicy={{ parkDelayMs: 300, flushTimeoutMs: 15_000 }}
             />,
@@ -122,8 +118,6 @@ describe("ActivityViewer — windowed mounting", () => {
                 activityId="windowed-scroll"
                 flags={{ allowSaveState: true }}
                 paginate={false}
-                standaloneUrl={WINDOWED_STANDALONE_URL}
-                cssUrl={WINDOWED_STANDALONE_CSS_URL}
                 addVirtualKeyboard={false}
                 mountPolicy={{
                     maxLiveViewers: 2,

--- a/test/cypress/component/helpers.ts
+++ b/test/cypress/component/helpers.ts
@@ -15,13 +15,7 @@ export const STANDALONE_CSS_URL = `${CDN}/style.css`;
 // on a cold CDN fetch.
 export const IFRAME_READY_TIMEOUT = 20_000;
 
-// The windowed-mounting specs park viewers, which requires a standalone
-// bundle that acknowledges `SPLICE.flushState` — true of the bundle
-// published alongside the installed doenetml-iframe version (the wrapper
-// treats a host-specified standaloneUrl as modern).
-export const WINDOWED_STANDALONE_URL = STANDALONE_URL;
-export const WINDOWED_STANDALONE_CSS_URL = STANDALONE_CSS_URL;
-
-// Parking additionally waits for the off-screen viewer's realm to boot far
-// enough to acknowledge the flush.
+// Parking waits for the off-screen viewer's realm to boot far enough to
+// acknowledge the flush. The windowed specs use docs at the park-gate
+// version (>= 0.7.21), so parking needs no host-specified standaloneUrl.
 export const PARK_TIMEOUT = 40_000;


### PR DESCRIPTION
## Summary

Release **0.7.21** ships the dark-mode and memory/coordination work from the recent PRs (#42–#45), and gates windowed-mounting *parking* on version ≥ 0.7.21 (`PARK_MIN_VERSION` in the iframe wrapper). This upgrades the dependency and updates every DoenetML version reference to `0.7.21`.

## Changes

- **Dependency:** bump `@doenet/doenetml-iframe` to `0.7.21` (peer `^0.7.21` + dev `0.7.21`) and refresh `package-lock.json`.
- **Sample activity:** update every document `version` in `dev/testActivity.json` to `0.7.21`.
- **Windowed cypress specs:** the specs pinned their docs at `0.7.4` and passed a host-specified `standaloneUrl` purely so the wrapper would treat the viewers as parking-capable. With docs at `0.7.21`, parking is gated on by version, so:
  - drop the `standaloneUrl`/`cssUrl` props from both mounts (bundle/CSS auto-resolve from the doc version),
  - remove the now-dead `WINDOWED_STANDALONE_URL` / `WINDOWED_STANDALONE_CSS_URL` helpers and their comment.
- **Package version:** bump `@doenet/assignment-viewer` to `0.1.0-alpha-16`.

The `darkMode` and `viewerUrls` specs still pass the generic `STANDALONE_URL` for their own rendering assertions (not parking) and are left unchanged.

## Notes

- Test fixtures in `src/test/collectDoenetmlVersions.test.ts` intentionally use mixed versions (`0.7.4`, `0.6.5`, `0.7`) to exercise mixed-version detection, so they are deliberately left as-is.
- Verified `@doenet/doenetml-iframe@0.7.21` and `@doenet/standalone@0.7.21` are published; `npm run build`, `tsc --noEmit`, and the vitest suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)