### PR TITLE
Upgrade to DoenetML 0.7.24

### DIFF
--- a/dev/testActivity.json
+++ b/dev/testActivity.json
@@ -16,7 +16,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>2+2=<answer>4</answer><selectFromSequence /></problem>",
-                    "version": "0.7.21",
+                    "version": "0.7.24",
                     "numVariants": 10
                 },
                 {
@@ -25,7 +25,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<problem>1+1=<answer>2</answer><selectFromSequence length='3' /></problem><problem>4+4=<answer>8</answer><selectFromSequence length='4' /></problem>",
-                    "version": "0.7.21",
+                    "version": "0.7.24",
                     "numVariants": 12
                 }
             ]
@@ -41,7 +41,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1A <graph><point name='P'/></graph><answer><award><when>$P.x > 0</when></award></answer></question>",
-                    "version": "0.7.21",
+                    "version": "0.7.24",
                     "numVariants": 1
                 },
                 {
@@ -49,7 +49,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1B <p>Enter: <select name='a'>a b c</select>. <answer>$a</answer></p></question>",
-                    "version": "0.7.21",
+                    "version": "0.7.24",
                     "numVariants": 3
                 },
                 {
@@ -57,7 +57,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1C <p>Enter: <selectFromSequence name='a' />. <answer>$a</answer></p></question>",
-                    "version": "0.7.21",
+                    "version": "0.7.24",
                     "numVariants": 10
                 },
                 {
@@ -65,7 +65,7 @@
                     "type": "singleDoc",
                     "isDescription": false,
                     "doenetML": "<question>Question 1D <p>Enter: <selectFromSequence name='a' length=\"5\" />.  <answer>$a</answer></p></question>",
-                    "version": "0.7.21",
+                    "version": "0.7.24",
                     "numVariants": 5
                 }
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doenet/assignment-viewer",
-    "version": "0.1.0-alpha-16",
+    "version": "0.1.0-alpha-17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@doenet/assignment-viewer",
-            "version": "0.1.0-alpha-16",
+            "version": "0.1.0-alpha-17",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "nanoid": "^5.1.6",
@@ -15,7 +15,7 @@
                 "seedrandom": "^3.0.5"
             },
             "devDependencies": {
-                "@doenet/doenetml-iframe": "0.7.21",
+                "@doenet/doenetml-iframe": "0.7.24",
                 "@eslint/js": "^9.39.1",
                 "@types/object-hash": "^3.0.6",
                 "@types/react": "^19.2.7",
@@ -39,7 +39,7 @@
                 "vitest": "^4.0.15"
             },
             "peerDependencies": {
-                "@doenet/doenetml-iframe": "^0.7.21",
+                "@doenet/doenetml-iframe": "^0.7.24",
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3"
             }
@@ -335,9 +335,9 @@
             }
         },
         "node_modules/@doenet/doenetml-iframe": {
-            "version": "0.7.21",
-            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.21.tgz",
-            "integrity": "sha512-Jjnh1BqBd+gqoh+K/OeHIHTUS0Ej4LjxztdMT/mjTcSiZvSs/b48VlVUEURoTE32z0rUZSFAzWQlC7FFEaQ8Wg==",
+            "version": "0.7.24",
+            "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.24.tgz",
+            "integrity": "sha512-fSyVUR7K+TCETiMITsKslOqXUk5FsU/3zb7wn4/7MWfcpdBTi6UZI2LuzpSj41W+IxUjSk911o7u6P3P4z9xOg==",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/assignment-viewer",
     "private": false,
     "description": "View assignments from questions written in DoenetML",
-    "version": "0.1.0-alpha-16",
+    "version": "0.1.0-alpha-17",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/assignment-viewer#readme",
     "type": "module",
@@ -38,7 +38,7 @@
         "prettier:check": "prettier --check ."
     },
     "peerDependencies": {
-        "@doenet/doenetml-iframe": "^0.7.21",
+        "@doenet/doenetml-iframe": "^0.7.24",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
     },
@@ -49,7 +49,7 @@
         "seedrandom": "^3.0.5"
     },
     "devDependencies": {
-        "@doenet/doenetml-iframe": "0.7.21",
+        "@doenet/doenetml-iframe": "0.7.24",
         "@eslint/js": "^9.39.1",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.7",

--- a/test/cypress/component/ActivityViewer.windowed.cy.tsx
+++ b/test/cypress/component/ActivityViewer.windowed.cy.tsx
@@ -15,10 +15,10 @@ function mkDoc(id: string, label: string): SingleDocSource {
         type: "singleDoc",
         isDescription: false,
         doenetML: `<p>${label}: <textInput name="ti" /></p><p>typed: $ti.value</p>`,
-        // 0.7.21 is the first version the iframe wrapper gates parking on
-        // (PARK_MIN_VERSION), so parking works without a host-specified
-        // standaloneUrl — the bundle/CSS auto-resolve from this version.
-        version: "0.7.21",
+        // At or above PARK_MIN_VERSION (0.7.21) the iframe wrapper gates
+        // parking on the doc version, so parking works without a
+        // host-specified standaloneUrl — the bundle/CSS auto-resolve.
+        version: "0.7.24",
         numVariants: 1,
     };
 }


### PR DESCRIPTION
Bumps `@doenet/doenetml-iframe` to 0.7.24 (peer + dev), the dev test activity docs, and the windowed-mounting spec's doc version. Releases as `0.1.0-alpha-17` so DoenetTools can pick up 0.7.24 through this package.

Unit tests (47) and all 14 Cypress component specs pass against the 0.7.24 CDN bundle, including the parking/windowed specs that boot the real standalone bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3bUTUym3xhuXLegDyTNZ2